### PR TITLE
fix: Do not include neighbors without an owner

### DIFF
--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -473,7 +473,7 @@ pub mod actions {
             let store = StoreTrait::new(world);
             let land = store.land(land_location);
 
-            let neighbors = self.payable._add_neighbors(store, land.location, false);
+            let neighbors = self.payable._add_neighbors(store, land.location, true);
             let mut total_rate: u64 = 0;
 
             let mut yield_info: Array<YieldInfo> = ArrayTrait::new();


### PR DESCRIPTION
As they mean that the land was nuked, so they don't bring any stake anymore

Closes #133 