### PR TITLE
[RUNE-118, RUNE-90] - Support lands levelup

### DIFF
--- a/client/src/lib/account.svelte.ts
+++ b/client/src/lib/account.svelte.ts
@@ -1,4 +1,4 @@
-import { useAccount, type AccountProvider } from './contexts/account';
+import { useAccount, type AccountProvider } from './contexts/account.svelte';
 import { type AccountInterface } from 'starknet';
 
 function wrapped<T>(value: T) {

--- a/client/src/lib/accounts/argentx.ts
+++ b/client/src/lib/accounts/argentx.ts
@@ -23,7 +23,10 @@ import {
 } from 'starknet';
 import { WALLET_API } from '@starknet-io/types-js';
 import { CommonStarknetWallet } from './getStarknet';
-import type { AccountProvider, StoredSession } from '$lib/contexts/account';
+import type {
+  AccountProvider,
+  StoredSession,
+} from '$lib/contexts/account.svelte';
 import { DojoProvider, type DojoCall } from '@dojoengine/core';
 
 const FUSE_DISABLE_ARGENT = true;

--- a/client/src/lib/accounts/burner.ts
+++ b/client/src/lib/accounts/burner.ts
@@ -5,7 +5,7 @@ import { BurnerManager, setupBurnerManager } from '@dojoengine/create-burner';
 import { getContext, setContext } from 'svelte';
 
 import { PUBLIC_DOJO_BURNER_ADDRESS } from '$env/static/public';
-import type { AccountProvider } from '$lib/contexts/account';
+import type { AccountProvider } from '$lib/contexts/account.svelte';
 
 const accountKey = Symbol('dojoAccountBurner');
 

--- a/client/src/lib/accounts/controller.ts
+++ b/client/src/lib/accounts/controller.ts
@@ -2,7 +2,10 @@ import { getContext, onMount, setContext } from 'svelte';
 import Controller from '@cartridge/controller';
 import { type DojoConfig } from '$lib/dojoConfig';
 import type { AccountInterface, WalletAccount } from 'starknet';
-import type { AccountProvider, StoredSession } from '$lib/contexts/account';
+import type {
+  AccountProvider,
+  StoredSession,
+} from '$lib/contexts/account.svelte';
 
 export class SvelteController extends Controller implements AccountProvider {
   _account?: AccountInterface;

--- a/client/src/lib/accounts/getStarknet.ts
+++ b/client/src/lib/accounts/getStarknet.ts
@@ -1,4 +1,7 @@
-import type { AccountProvider, StoredSession } from '$lib/contexts/account';
+import type {
+  AccountProvider,
+  StoredSession,
+} from '$lib/contexts/account.svelte';
 import { dojoConfig } from '$lib/dojoConfig';
 import { getStarknet } from '@starknet-io/get-starknet-core';
 import { WALLET_API } from '@starknet-io/types-js';

--- a/client/src/lib/api/land.svelte.ts
+++ b/client/src/lib/api/land.svelte.ts
@@ -105,7 +105,7 @@ export function useLands(): LandsStore | undefined {
 
   // We are using this to ensure that we are getting the latest provider, not an old one.
   const account = () => {
-    return accountManager.getProvider();
+    return accountManager!.getProvider();
   };
 
   (async () => {

--- a/client/src/lib/api/land.svelte.ts
+++ b/client/src/lib/api/land.svelte.ts
@@ -24,7 +24,7 @@ export type TransactionResult = Promise<
   | undefined
 >;
 
-export type Level = keyof LevelModel;
+export type Level = 0 | 1 | 2;
 
 export type LandSetup = {
   tokenForSaleAddress: string;
@@ -162,7 +162,7 @@ export function useLands(): LandsStore | undefined {
             | 'auction'
             | 'house',
           owner: land.owner,
-          level: fromDojoLevel(land.level) ?? 'None',
+          level: fromDojoLevel(land.level),
           sellPrice: CurrencyAmount.fromUnscaled(land.sell_price),
           tokenUsed: getTokenInfo(land.token_used)?.name ?? 'Unknown Token',
           tokenAddress: land.token_used,

--- a/client/src/lib/components/auction/auction-modal.svelte
+++ b/client/src/lib/components/auction/auction-modal.svelte
@@ -8,9 +8,11 @@
     selectedLand,
     selectedLandMeta,
     uiStore,
+    type SelectedLand,
   } from '$lib/stores/stores.svelte';
   import { toHexWithPadding } from '$lib/utils';
   import { CurrencyAmount } from '$lib/utils/CurrencyAmount';
+  import { onMount } from 'svelte';
   import BuySellForm from '../buy/buy-sell-form.svelte';
   import LandOverview from '../land/land-overview.svelte';
   import ThreeDots from '../loading/three-dots.svelte';
@@ -23,6 +25,12 @@
   let extended = $state(false);
   let loading = $state(false);
   let fetching = $state(false);
+
+  let land: SelectedLand = $state();
+
+  onMount(() => {
+    land = $selectedLandMeta;
+  });
 
   let currentPrice = $state<CurrencyAmount>();
   let priceDisplay = $derived(currentPrice?.toString());
@@ -64,7 +72,7 @@
       );
 
       if (result?.transaction_hash) {
-        await accountManager
+        await accountManager!
           .getProvider()
           ?.getWalletAccount()
           ?.waitForTransaction(result.transaction_hash);
@@ -99,11 +107,11 @@
   });
 
   const fetchCurrentPrice = () => {
-    if (!$selectedLand) {
+    if (!land) {
       return;
     }
 
-    $selectedLandMeta?.getCurrentAuctionPrice().then((res) => {
+    land?.getCurrentAuctionPrice().then((res) => {
       currentPrice = res;
       fetching = false;
     });
@@ -120,8 +128,8 @@
     <div class="flex flex-col items-center">
       <div class="flex gap-6">
         <div class="flex flex-col items-center justify-center p-5 gap-3">
-          {#if $selectedLandMeta}
-            <LandOverview land={$selectedLandMeta} size="lg" />
+          {#if land}
+            <LandOverview {land} size="lg" />
           {/if}
           <div class="text-shadow-none">0 watching</div>
           <div class="flex items-center gap-1">
@@ -165,12 +173,12 @@
           <div class="text-ponzi-huge text-3xl"></div>
           <div class="flex items-center gap-2">
             <div class="text-3xl text-ponzi-huge text-white">
-              {$selectedLandMeta?.token?.symbol}
+              {land?.token?.symbol}
             </div>
             <img
               class="w-6 h-6"
-              src={$selectedLandMeta?.token?.images.icon}
-              alt="{$selectedLandMeta?.token?.symbol} icon"
+              src={land?.token?.images.icon}
+              alt="{land?.token?.symbol} icon"
             />
           </div>
         </div>

--- a/client/src/lib/components/auction/auction-modal.svelte
+++ b/client/src/lib/components/auction/auction-modal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { LandSetup } from '$lib/api/land.svelte';
   import { useLands } from '$lib/api/land.svelte';
-  import { useAccount } from '$lib/contexts/account';
+  import { useAccount } from '$lib/contexts/account.svelte';
   import type { Token } from '$lib/interfaces';
   import type { Auction } from '$lib/models.gen';
   import {

--- a/client/src/lib/components/buy/buy-modal.svelte
+++ b/client/src/lib/components/buy/buy-modal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { useLands, type LandSetup } from '$lib/api/land.svelte';
-  import { useAccount } from '$lib/contexts/account';
+  import { useAccount } from '$lib/contexts/account.svelte';
   import type { Token } from '$lib/interfaces';
   import { uiStore, selectedLandMeta } from '$lib/stores/stores.svelte';
   import { toHexWithPadding } from '$lib/utils';

--- a/client/src/lib/components/land/hud/land-hud-other.svelte
+++ b/client/src/lib/components/land/hud/land-hud-other.svelte
@@ -22,12 +22,6 @@
         </a>
       </p>
     </div>
-    <div class="flex justify-between">
-      <p class="opacity-50">Level</p>
-      <p>
-        {$selectedLandMeta?.level}
-      </p>
-    </div>
 
     <div class="flex justify-between">
       <p class="opacity-50">Price</p>

--- a/client/src/lib/components/land/hud/land-hud-owned.svelte
+++ b/client/src/lib/components/land/hud/land-hud-owned.svelte
@@ -22,12 +22,6 @@
     <LandOverview land={$selectedLandMeta} />
   {/if}
   <div class="w-full text-shadow-none flex flex-col leading-none text-lg">
-    <div class="flex justify-between">
-      <p class="opacity-50">Level</p>
-      <p>
-        {$selectedLandMeta?.level}
-      </p>
-    </div>
     {#if $selectedLandMeta?.tokenUsed}
       <div class="flex justify-between">
         <p class="opacity-50">Token</p>

--- a/client/src/lib/components/land/land-overview.svelte
+++ b/client/src/lib/components/land/land-overview.svelte
@@ -4,6 +4,9 @@
 
   const { land, size = 'sm' }: { land: LandWithActions; size?: 'sm' | 'lg' } =
     $props();
+
+  const OFF_IMAGE = '/assets/ui/star/off.png';
+  const ON_IMAGE = '/assets/ui/star/on.png';
 </script>
 
 <div class="flex flex-col">
@@ -27,6 +30,28 @@
       <span class="text-ponzi {size == 'lg' ? 'text-xl' : 'text-lg'}"
         >{locationIntToString(land.location)}</span
       >
+    </div>
+
+    <div
+      class="absolute -bottom-3 left-0 w-full leading-none flex flex-row justify-center"
+    >
+      <img
+        src={land.level >= 0 ? ON_IMAGE : OFF_IMAGE}
+        class="w-5"
+        alt="no star"
+      />
+
+      <img
+        src={land.level >= 1 ? ON_IMAGE : OFF_IMAGE}
+        class="w-5"
+        alt="no star"
+      />
+
+      <img
+        src={land.level >= 2 ? ON_IMAGE : OFF_IMAGE}
+        class="w-5"
+        alt="no star"
+      />
     </div>
   </div>
 </div>

--- a/client/src/lib/components/wallet/SelectWalletModal.svelte
+++ b/client/src/lib/components/wallet/SelectWalletModal.svelte
@@ -7,7 +7,7 @@
     setupAccount,
     USE_BURNER,
     useAccount,
-  } from '$lib/contexts/account';
+  } from '$lib/contexts/account.svelte';
   import Button from '../ui/button/button.svelte';
   import type { StarknetWindowObject } from '@starknet-io/get-starknet-core';
 

--- a/client/src/lib/components/wallet/SwitchChainModal.svelte
+++ b/client/src/lib/components/wallet/SwitchChainModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { PUBLIC_DOJO_CHAIN_ID } from '$env/static/public';
-  import { useAccount } from '$lib/contexts/account';
+  import { useAccount } from '$lib/contexts/account.svelte';
   import { onMount } from 'svelte';
   import Button from '../ui/button/button.svelte';
   import { Card } from '../ui/card';

--- a/client/src/lib/contexts/account.svelte.ts
+++ b/client/src/lib/contexts/account.svelte.ts
@@ -13,6 +13,8 @@ import { dojoConfig } from '$lib/dojoConfig';
 import getStarknet from '@starknet-io/get-starknet-core';
 import { WALLET_API } from '@starknet-io/types-js';
 import {
+  Account,
+  cairo,
   WalletAccount,
   type AccountInterface,
   shortString,
@@ -410,23 +412,22 @@ export class AccountManager {
   // TODO: Maybe mirror the some of the AccountProvider functions to make it easier to use?
 }
 
-export function setupAccount(): Promise<AccountManager | null> {
-  if (!browser) {
-    return Promise.resolve(null);
+let state = $state<AccountManager | null>(null);
+
+export function setupAccount(): Promise<AccountManager> {
+  if (state != null) {
+    return state.wait();
   }
 
-  if (getContext(accountManager) != null) {
-    return getContext<AccountManager>(accountManager).wait();
-  }
   const manager = new AccountManager();
 
-  setContext(accountManager, manager);
+  state = manager;
 
   return manager.wait();
 }
 
 export function useAccount() {
-  const manager = getContext<AccountManager>(accountManager);
+  const manager = state;
   if (manager == null) {
     console.error(
       'You are using useAccount(), but the setupAccount() function has not been called.',

--- a/client/src/lib/contexts/client.svelte.ts
+++ b/client/src/lib/contexts/client.svelte.ts
@@ -41,18 +41,27 @@ async function _setupDojo(config: DojoConfig) {
     client: await wrappedActions(provider),
   };
 }
+
+let state: { value: Client | undefined } = $state({ value: undefined });
+
 // Set the context (This function CANNOT be async due to setContext not working otherwise)
-export function setupClient(config: DojoConfig): Promise<Client | undefined> {
-  let result: { value?: Client } = {};
+export async function setupClient(
+  config: DojoConfig,
+): Promise<Client | undefined> {
+  if (state?.value == undefined) {
+    // set the value in the context
+    const result = await _setupDojo(config);
 
-  // set the value in the context
-  setContext(dojoKey, result);
+    state = { value: result };
 
-  return _setupDojo(config).then((value) => (result.value = value));
+    return result;
+  } else {
+    return Promise.resolve(state.value);
+  }
 }
 
 export function useClient(): Client {
-  const contextValue = getContext<{ value?: Client }>(dojoKey).value;
+  const contextValue = state.value;
 
   if (contextValue == null) {
     throw 'The context is null! Please await for setupDojo before using components containing useDojo() !';

--- a/client/src/lib/contexts/dojo.ts
+++ b/client/src/lib/contexts/dojo.ts
@@ -1,8 +1,13 @@
-import { AccountManager, useAccount, type AccountProvider } from './account';
-import { useClient } from './client';
-import { useStore } from './store';
+import {
+  AccountManager,
+  useAccount,
+  type AccountProvider,
+} from './account.svelte';
+import { useClient } from './client.svelte';
+import { useStore } from './store.svelte';
 
 export function useDojo() {
+  console.log('Accessing useDojo!', new Error().stack);
   const client = useClient();
   const accountManager = useAccount();
   const store = useStore();

--- a/client/src/lib/contexts/store.svelte.ts
+++ b/client/src/lib/contexts/store.svelte.ts
@@ -8,6 +8,8 @@ import { getContext, setContext } from 'svelte';
 
 const storeKey = Symbol('dojo_store');
 
+let state: { value?: Store } = $state({});
+
 export type Store = ReturnType<typeof setupStore>;
 
 export function setupStore() {
@@ -18,13 +20,14 @@ export function setupStore() {
     >,
   );
 
-  setContext(storeKey, value);
+  state = { value };
 
   return value;
 }
 
 export function useStore(): Store {
-  const context = getContext<Store | undefined>(storeKey);
+  const context = state.value;
+
   if (context == undefined) {
     throw 'Store is not set!';
   } else {

--- a/client/src/lib/stores/stores.svelte.ts
+++ b/client/src/lib/stores/stores.svelte.ts
@@ -48,36 +48,40 @@ export function selectLand(land: LandWithActions) {
   selectedLandPosition.set(land.location);
 }
 
-export const selectedLandMeta: Readable<
-  | (LandWithActions & {
-      token?: Token;
-    })
-  | undefined
-> = derived(selectedLand, ($selectedLand) => {
-  if ($selectedLand) {
-    if ($selectedLand?.owner == undefined) {
+export type LandWithToken = LandWithActions & {
+  token?: Token;
+};
+
+export type SelectedLand = LandWithToken | undefined;
+
+export const selectedLandMeta: Readable<SelectedLand> = derived(
+  selectedLand,
+  ($selectedLand) => {
+    if ($selectedLand) {
+      if ($selectedLand?.owner == undefined) {
+        return {
+          ...$selectedLand,
+          isEmpty: true,
+        };
+      }
+      // --- Derived Props ---
+
+      // get token info from tokenAddress from data
+      const token = data.availableTokens.find(
+        (token) => token.address === $selectedLand!.tokenAddress,
+      );
+
+      // --- Helper Functions --- TODO
+
       return {
         ...$selectedLand,
-        isEmpty: true,
+        isEmpty: false,
+        token,
       };
     }
-    // --- Derived Props ---
-
-    // get token info from tokenAddress from data
-    const token = data.availableTokens.find(
-      (token) => token.address === $selectedLand!.tokenAddress,
-    );
-
-    // --- Helper Functions --- TODO
-
-    return {
-      ...$selectedLand,
-      isEmpty: false,
-      token,
-    };
-  }
-  return undefined;
-});
+    return undefined;
+  },
+);
 
 export const mousePosCoords = writable<{
   x: number;

--- a/client/src/lib/utils/avnu.svelte.ts
+++ b/client/src/lib/utils/avnu.svelte.ts
@@ -7,7 +7,7 @@ import {
 } from '@avnu/avnu-sdk';
 import type { CurrencyAmount } from './CurrencyAmount';
 import type { Token } from '$lib/interfaces';
-import { useAccount } from '$lib/contexts/account';
+import { useAccount } from '$lib/contexts/account.svelte';
 
 export type BaseQuoteParams = {
   sellToken: Token;

--- a/client/src/lib/utils/level.ts
+++ b/client/src/lib/utils/level.ts
@@ -2,6 +2,12 @@ import type { Level } from '$lib/api/land.svelte';
 import type { LevelEnum as LevelModel } from '$lib/models.gen';
 
 export function fromDojoLevel(level: LevelModel): Level | undefined {
+  if (typeof level == 'string') {
+    return level as Level;
+  }
+
+  console.log('level:', level);
+
   return (
     (Object.entries(level ?? {}).filter(
       ([k, v]) => v != undefined,

--- a/client/src/lib/utils/level.ts
+++ b/client/src/lib/utils/level.ts
@@ -6,7 +6,7 @@ export function fromDojoLevel(level: LevelModel): Level | undefined {
     return level as Level;
   }
 
-  console.log('level:', level);
+  console.log('level:', level, typeof level);
 
   return (
     (Object.entries(level ?? {}).filter(

--- a/client/src/lib/utils/level.ts
+++ b/client/src/lib/utils/level.ts
@@ -1,16 +1,28 @@
 import type { Level } from '$lib/api/land.svelte';
 import type { LevelEnum as LevelModel } from '$lib/models.gen';
 
-export function fromDojoLevel(level: LevelModel): Level | undefined {
+export function getEnumVariant(level: LevelModel) {
   if (typeof level == 'string') {
-    return level as Level;
+    return level;
   }
 
   console.log('level:', level, typeof level);
 
   return (
-    (Object.entries(level ?? {}).filter(
-      ([k, v]) => v != undefined,
-    )?.[0]?.[0] as Level) ?? undefined
+    Object.entries(level ?? {}).filter(([k, v]) => v != undefined)?.[0]?.[0] ??
+    undefined
   );
+}
+
+export function fromDojoLevel(level: LevelModel): Level {
+  switch (getEnumVariant(level)) {
+    case 'None':
+      return 0;
+    case 'First':
+      return 1;
+    case 'Second':
+      return 2;
+    default:
+      return 0;
+  }
 }

--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import SelectWalletModal from '$lib/components/wallet/SelectWalletModal.svelte';
-  import { setupAccount } from '$lib/contexts/account';
+  import { setupAccount } from '$lib/contexts/account.svelte';
   import { onMount } from 'svelte';
 
   import '../app.css';

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script>
   import { goto } from '$app/navigation';
-  import { setupAccount, useAccount } from '$lib/contexts/account';
+  import { setupAccount, useAccount } from '$lib/contexts/account.svelte';
   import { dojoConfig } from '$lib/dojoConfig';
 
   // setup account

--- a/client/src/routes/admin/+page.svelte
+++ b/client/src/routes/admin/+page.svelte
@@ -5,9 +5,9 @@
   import ThreeDots from '$lib/components/loading/three-dots.svelte';
   import { Button } from '$lib/components/ui/button';
   import { Input } from '$lib/components/ui/input';
-  import { setupAccount } from '$lib/contexts/account';
-  import { setupClient } from '$lib/contexts/client';
-  import { setupStore } from '$lib/contexts/store';
+  import { setupAccount } from '$lib/contexts/account.svelte';
+  import { setupClient } from '$lib/contexts/client.svelte';
+  import { setupStore } from '$lib/contexts/store.svelte';
   import { dojoConfig } from '$lib/dojoConfig';
   import type { Token } from '$lib/interfaces';
   import { selectedLand } from '$lib/stores/stores.svelte';

--- a/client/src/routes/game/+page.svelte
+++ b/client/src/routes/game/+page.svelte
@@ -1,8 +1,8 @@
 <script>
   import { dev } from '$app/environment';
-  import { setupAccount } from '$lib/contexts/account';
-  import { setupClient } from '$lib/contexts/client';
-  import { setupStore } from '$lib/contexts/store';
+  import { setupAccount } from '$lib/contexts/account.svelte';
+  import { setupClient } from '$lib/contexts/client.svelte';
+  import { setupStore } from '$lib/contexts/store.svelte';
   import { dojoConfig } from '$lib/dojoConfig';
   import Map from '$lib/components/map/map.svelte';
   import Ui from '$lib/components/ui.svelte';

--- a/client/src/routes/test/+page.svelte
+++ b/client/src/routes/test/+page.svelte
@@ -1,9 +1,9 @@
 <script>
   import Swap from '$lib/components/swap/swap.svelte';
 
-  import { setupAccount } from '$lib/contexts/account';
-  import { setupClient } from '$lib/contexts/client';
-  import { setupStore } from '$lib/contexts/store';
+  import { setupAccount } from '$lib/contexts/account.svelte';
+  import { setupClient } from '$lib/contexts/client.svelte';
+  import { setupStore } from '$lib/contexts/store.svelte';
   import { dojoConfig } from '$lib/dojoConfig';
 
   const promise = Promise.all([

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
   server: {
     host: 'localhost',
     port: 3000,
+    fs: {
+      allow: ['../constracts/manifest_*.json'],
+    },
   },
   resolve: {
     alias: {
@@ -23,6 +26,7 @@ export default defineConfig({
   define: {
     global: {},
   },
+
   ssr: {
     noExternal: ['@dojoengine/torii-client'],
   },


### PR DESCRIPTION
feat!: Migrated all contexts to use svelte 5's `$state`.

Allows us to fix RUNE-118, where the HUD doesn't change when an action is taken (like building levelup)

## TODO:
- [x] Show the level in the land overview
- [x] Remove the placeholder building level in the descriptions
- [x] Take a snapshot of the land when showing a modal (to make it not update in the popup)