### PR TITLE
[RUNE-103] - feat: implement spiral organic expansion for auctions

### DIFF
--- a/contracts/src/consts.cairo
+++ b/contracts/src/consts.cairo
@@ -4,7 +4,8 @@ pub const TAX_RATE: u64 = 2;
 pub const BASE_TIME: u64 = 3600;
 pub const PRICE_DECREASE_RATE: u64 = 2;
 pub const TIME_SPEED: u32 = 4;
-pub const MAX_AUCTIONS: u8 = 10;
+pub const MAX_AUCTIONS: u8 = 12;
+pub const MAX_NEW_AUCTIONS: u8 = 3;
 pub const DECAY_RATE: u64 = 100;
 //TODO:The floor price can be an u8, depends how we want to handle it
 pub const FLOOR_PRICE: u256 = 1;

--- a/contracts/src/helpers/coord.cairo
+++ b/contracts/src/helpers/coord.cairo
@@ -61,6 +61,42 @@ fn down(index: u64) -> Option<u64> {
     }
 }
 
+fn up_left(index: u64) -> Option<u64> {
+    let (row, col) = index_to_position(index);
+    if row == 0 || col == 0 {
+        Option::None
+    } else {
+        Option::Some(position_to_index(row - 1, col - 1))
+    }
+}
+
+fn up_right(index: u64) -> Option<u64> {
+    let (row, col) = index_to_position(index);
+    if row == 0 || col == GRID_WIDTH - 1 {
+        Option::None
+    } else {
+        Option::Some(position_to_index(row - 1, col + 1))
+    }
+}
+
+fn down_left(index: u64) -> Option<u64> {
+    let (row, col) = index_to_position(index);
+    if row == GRID_WIDTH - 1 || col == 0 {
+        Option::None
+    } else {
+        Option::Some(position_to_index(row + 1, col - 1))
+    }
+}
+
+fn down_right(index: u64) -> Option<u64> {
+    let (row, col) = index_to_position(index);
+    if row == GRID_WIDTH - 1 || col == GRID_WIDTH - 1 {
+        Option::None
+    } else {
+        Option::Some(position_to_index(row + 1, col + 1))
+    }
+}
+
 fn is_valid_position(index: u64) -> bool {
     index < GRID_WIDTH * GRID_WIDTH
 }
@@ -83,16 +119,16 @@ fn max_neighbors(index: u64) -> u64 {
     }
 
     // Diagonal neighbors
-    if up(index).is_some() && right(index).is_some() {
+    if up_left(index).is_some() {
         count += 1;
     }
-    if up(index).is_some() && left(index).is_some() {
+    if up_right(index).is_some() {
         count += 1;
     }
-    if down(index).is_some() && right(index).is_some() {
+    if down_left(index).is_some() {
         count += 1;
     }
-    if down(index).is_some() && left(index).is_some() {
+    if down_right(index).is_some() {
         count += 1;
     }
 

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -39,6 +39,7 @@ mod utils {
     mod common_strucs;
     mod get_neighbors;
     mod level_up;
+    mod spiral;
 }
 
 #[cfg(test)]

--- a/contracts/src/utils/spiral.cairo
+++ b/contracts/src/utils/spiral.cairo
@@ -1,0 +1,35 @@
+use ponzi_land::helpers::coord::{
+    left, right, up, down, index_to_position, position_to_index, up_left, up_right, down_left,
+    down_right
+};
+use ponzi_land::store::{Store, StoreTrait};
+use ponzi_land::consts::{MAX_AUCTIONS, MAX_NEW_AUCTIONS};
+
+#[derive(Copy, Drop, Serde, starknet::Store)]
+struct SpiralState {
+    row: u64,
+    col: u64,
+    advance: u64,
+    direction: u8
+}
+
+
+fn should_continue_adding_auctions(added: u8, active_auctions: u8, directions_tried: u8) -> bool {
+    added < MAX_NEW_AUCTIONS && active_auctions < MAX_AUCTIONS && directions_tried < 8
+}
+
+// Helper function to get next position based on direction
+fn get_next_position(direction: u8, center_pos: u64,) -> Option<u64> {
+    match direction {
+        0 => left(center_pos),
+        1 => up_left(center_pos),
+        2 => up(center_pos),
+        3 => up_right(center_pos),
+        4 => right(center_pos),
+        5 => down_right(center_pos),
+        6 => down(center_pos),
+        7 => down_left(center_pos),
+        _ => Option::None
+    }
+}
+


### PR DESCRIPTION
Added `add_spiral_auctions` function to enable organic growth of auctions
from bided lands using an 8-direction spiral pattern. Limit expansion
to 3 new auctions per bid, up to a maximum of 12 active auctions.