### PR TITLE
Refactor for reimburse function

### DIFF
--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -536,9 +536,11 @@ pub mod actions {
 
             let mut token_ratios = self
                 .stake
-                .reimburse_and_return_ratios(store, active_lands_with_taxes.span());
+                .calculate_token_ratios(active_lands_with_taxes.span());
 
-            self.distribute_adjusted_taxes(active_lands_with_taxes, token_ratios);
+            self.stake.reimburse(store, active_lands_with_taxes.span(), ref token_ratios);
+
+            self.distribute_adjusted_taxes(active_lands_with_taxes, ref token_ratios);
         }
 
 
@@ -894,7 +896,7 @@ pub mod actions {
         fn distribute_adjusted_taxes(
             ref self: ContractState,
             active_lands_with_taxes: Array<LandWithTaxes>,
-            mut token_ratios: Felt252Dict<Nullable<u256>>
+            ref token_ratios: Felt252Dict<Nullable<u256>>
         ) {
             for land_with_taxes in active_lands_with_taxes
                 .span() {
@@ -912,7 +914,6 @@ pub mod actions {
                                     FromNullableResult::Null => 0_u256,
                                     FromNullableResult::NotNull(val) => val.unbox(),
                                 };
-
                                 let adjuested_tax_amount = calculate_refund_amount(
                                     tax.amount, token_ratio
                                 );
@@ -926,7 +927,6 @@ pub mod actions {
                                     )
                             }
                     }
-
                     self.taxes._claim(adjusted_taxes, land.owner, land.location);
                 }
         }

--- a/contracts/src/tests/actions.cairo
+++ b/contracts/src/tests/actions.cairo
@@ -955,6 +955,7 @@ fn test_reimburse_stakes() {
     let erc20_neighbor_2 = deploy_erc20_with_pool(
         ekubo_testing_dispatcher, main_currency.contract_address, NEIGHBOR_2()
     );
+
     let erc20_neighbor_3 = deploy_erc20_with_pool(
         ekubo_testing_dispatcher, main_currency.contract_address, NEIGHBOR_3()
     );
@@ -982,10 +983,9 @@ fn test_reimburse_stakes() {
 
     initialize_land(actions_system, main_currency, RECIPIENT(), 1251, 500, 157, main_currency);
 
-    let land_locations = array![1280, 1281, 1216, 1217, 1250, 1251];
+    let land_locations = array![1280, 1216, 1217, 1250, 1251];
     let tokens = array![
-        main_currency,
-        erc20_neighbor_1,
+        main_currency, // erc20_neighbor_1,
         erc20_neighbor_2,
         erc20_neighbor_3,
         main_currency,
@@ -1018,9 +1018,6 @@ fn test_claim_all() {
         ekubo_testing_dispatcher, main_currency.contract_address, NEIGHBOR_1()
     );
 
-    let erc20_neighbor_2 = deploy_erc20_with_pool(
-        ekubo_testing_dispatcher, main_currency.contract_address, NEIGHBOR_2()
-    );
     let erc20_neighbor_3 = deploy_erc20_with_pool(
         ekubo_testing_dispatcher, main_currency.contract_address, NEIGHBOR_3()
     );


### PR DESCRIPTION
Split the reimburse and return ratios function into two, keeping in mind the single responsibility principle