### PR TITLE
add claim_all into toolbar of my lands

### DIFF
--- a/client/src/lib/api/land.svelte.ts
+++ b/client/src/lib/api/land.svelte.ts
@@ -243,7 +243,7 @@ export function useLands(): LandsStore | undefined {
         },
         async getNextClaim() {
           const result = (await sdk.client.actions.getNextClaimInfo(
-            ensureNumber(land.location),
+            land.location,
           )) as any[] | undefined;
           return result?.map((claim) => ({
             amount: CurrencyAmount.fromUnscaled(claim.amount),

--- a/client/src/lib/components/land/land-tax-claimer.svelte
+++ b/client/src/lib/components/land/land-tax-claimer.svelte
@@ -41,22 +41,6 @@
   });
   let timing = $derived(claimStore.value[land.location].claimable);
 
-  async function handleClaimFromCoin(e: Event) {
-    console.log('claiming from coin');
-    fetchTaxes();
-
-    if (!land.token) {
-      console.error("Land doesn't have a token");
-      return;
-    }
-
-    claimAllOfToken(land.token, dojo, account()?.getWalletAccount()!).catch(
-      (e) => {
-        console.error('error claiming from coin', e);
-      },
-    );
-  }
-
   async function handleSingleClaim(e: Event) {
     console.log('claiming from single land');
     fetchTaxes();
@@ -73,7 +57,6 @@
 
   async function fetchTaxes() {
     const result = await getAggregatedTaxes(land);
-
     aggregatedTaxes = result.taxes;
 
     const nukables = result.nukables;

--- a/client/src/lib/components/toolbar/toolbar-drawer-lands.svelte
+++ b/client/src/lib/components/toolbar/toolbar-drawer-lands.svelte
@@ -1,17 +1,59 @@
 <script lang="ts">
+  import type { LandWithActions } from '$lib/api/land.svelte';
+  import { useDojo } from '$lib/contexts/dojo';
+  import { claimAllOfToken } from '$lib/stores/claim.svelte';
   import { usePlayerLands } from '$lib/stores/stores.svelte';
   import { uiStore } from '$lib/stores/ui.store.svelte';
+  import { groupLands } from '$lib/utils';
   import LandInfoCard from '../land/land-info-card.svelte';
   import { ScrollArea } from '../ui/scroll-area';
 
+  const dojo = useDojo();
+  const account = () => {
+    return dojo.accountManager?.getProvider();
+  };
+
+  async function handleClaimFromCoin(land: LandWithActions) {
+    console.log('claiming from coin');
+
+    if (!land.token) {
+      console.error("Land doesn't have a token");
+      return;
+    }
+
+    claimAllOfToken(land.token, dojo, account()?.getWalletAccount()!).catch(
+      (e) => {
+        console.error('error claiming from coin', e);
+      },
+    );
+  }
+
   let playerLandsStore = usePlayerLands();
+  const groupedLands = groupLands($playerLandsStore);
 </script>
 
 <div class="text-lg font-semibold">My Lands</div>
 <ScrollArea class="h-full w-full relative">
   <div class="flex flex-col items-center">
-    {#each $playerLandsStore as land}
-      <LandInfoCard {land} />
+    {#each groupedLands as [key, lands]}
+      <div class="w-full mb-4">
+        <div class="font-bold text-md mb-2 mt-2">
+          {lands[0].token?.name}
+        </div>
+        <div class="flex flex-col gap-2">
+          {#each lands as land}
+            <LandInfoCard {land} />
+          {/each}
+        </div>
+        <div class="flex justify-end mt-2">
+          <button
+            class="my-2 px-4 py-2 rounded bg-yellow-500 text-white hover:opacity-90 transition"
+            onclick={() => handleClaimFromCoin(lands[0])}
+          >
+            Claim All
+          </button>
+        </div>
+      </div>
     {/each}
     {#if $playerLandsStore.length === 0}
       <div class="text-center text-sm text-gray-400">

--- a/client/src/lib/stores/claim.svelte.ts
+++ b/client/src/lib/stores/claim.svelte.ts
@@ -25,60 +25,34 @@ export async function claimAllOfToken(
   { client: sdk, accountManager }: ReturnType<typeof useDojo>,
   account: Account | AccountInterface,
 ) {
-  // get all the lands with the same token
   const landsWithThisToken = Object.values(claimStore.value)
     .filter((claim) => claim.land.token?.address === token.address)
     .map((claim) => claim.land);
 
-  const aggregatedTaxes = await Promise.all(
-    landsWithThisToken.map(async (land) => {
-      const result = await getAggregatedTaxes(land);
-      return result.taxes;
-    }),
-  );
+  const landsToClaim: LandWithActions[][] = [];
+  for (let i = 0; i < landsWithThisToken.length; i += 10) {
+    landsToClaim.push(landsWithThisToken.slice(i, i + 10));
+  }
 
-  // call claim multicall to claim all the tokens at once
-  await sdk.client.actions
-    .claimAll(
-      account,
-      landsWithThisToken.map((land) => land.location as BigNumberish),
-    )
-    .then(() => {
-      // update the last claim time for all the lands
-      landsWithThisToken.forEach((land) => {
-        claimStore.value[land.location].lastClaimTime = Date.now();
-        claimStore.value[land.location].animating = true;
-        claimStore.value[land.location].claimable = false;
-      });
+  for (const batch of landsToClaim) {
+    const batchAggregatedTaxes = await Promise.all(
+      batch.map(async (land) => {
+        const result = await getAggregatedTaxes(land);
+        return result;
+      }),
+    );
 
-      setTimeout(() => {
-        landsWithThisToken.forEach((land) => {
-          claimStore.value[land.location].animating = false;
+    await sdk.client.actions
+      .claimAll(
+        account,
+        batch.map((land) => land.location as BigNumberish),
+      )
+      .then((value) => {
+        batchAggregatedTaxes.forEach((result) => {
+          handlePostClaim(batch, result, value.transaction_hash);
         });
-      }, 2000);
-
-      setTimeout(() => {
-        landsWithThisToken.forEach((land) => {
-          if (land.type === 'house') {
-            claimStore.value[land.location].claimable = true;
-          }
-        });
-      }, 30 * 1000);
-
-      claimQueue.update((queue) => {
-        return [
-          ...queue,
-          ...aggregatedTaxes.flatMap((taxData) => {
-            return taxData.map((tax) => {
-              const token = getTokenInfo(tax.tokenAddress);
-              tax.totalTax.setToken(token);
-              console.log('total tax when updating queue', tax.totalTax);
-              return tax.totalTax;
-            });
-          }),
-        ];
       });
-    });
+  }
 }
 
 export async function claimSingleLand(
@@ -91,38 +65,60 @@ export async function claimSingleLand(
   await sdk.client.actions
     .claim(account, land.location as BigNumberish)
     .then((value) => {
-      notificationQueue.addNotification(value.transaction_hash, 'claim');
-
-      claimStore.value[land.location].lastClaimTime = Date.now();
-      claimStore.value[land.location].animating = true;
-      claimStore.value[land.location].claimable = false;
-
-      result.nukables.forEach((land) => {
-        if (land.nukable) {
-          markAsNuking(land.location);
-          claimStore.value[land.location].land.type = 'auction';
-        }
-      });
-
-      setTimeout(() => {
-        claimStore.value[land.location].animating = false;
-      }, 2000);
-
-      setTimeout(() => {
-        if (land.type === 'house') {
-          claimStore.value[land.location].claimable = true;
-        }
-      }, 30 * 1000);
-
-      claimQueue.update((queue) => {
-        return [
-          ...queue,
-          ...result.taxes.map((tax) => {
-            const token = getTokenInfo(tax.tokenAddress);
-            tax.totalTax.setToken(token);
-            return tax.totalTax;
-          }),
-        ];
-      });
+      handlePostClaim([land], result, value.transaction_hash);
     });
+}
+
+// Agregar esta función helper al inicio del archivo
+async function handlePostClaim(
+  lands: LandWithActions[],
+  result: { nukables: any[]; taxes: any[] },
+  transactionHash: string,
+) {
+  if (transactionHash) {
+    notificationQueue.addNotification(transactionHash, 'claim');
+  }
+
+  // Update claim states for all lands
+  lands.forEach((land) => {
+    claimStore.value[land.location].lastClaimTime = Date.now();
+    claimStore.value[land.location].animating = true;
+    claimStore.value[land.location].claimable = false;
+  });
+
+  // Handle nukables
+  result.nukables.forEach((land) => {
+    if (land.nukable) {
+      markAsNuking(land.location);
+      claimStore.value[land.location].land.type = 'auction';
+    }
+  });
+
+  // Animation timeout
+  setTimeout(() => {
+    lands.forEach((land) => {
+      claimStore.value[land.location].animating = false;
+    });
+  }, 2000);
+
+  // Claimable timeout
+  setTimeout(() => {
+    lands.forEach((land) => {
+      if (land.type === 'house') {
+        claimStore.value[land.location].claimable = true;
+      }
+    });
+  }, 30 * 1000);
+
+  // Update claim queue
+  claimQueue.update((queue) => {
+    return [
+      ...queue,
+      ...result.taxes.map((tax) => {
+        const token = getTokenInfo(tax.tokenAddress);
+        tax.totalTax.setToken(token);
+        return tax.totalTax;
+      }),
+    ];
+  });
 }

--- a/client/src/lib/stores/claim.svelte.ts
+++ b/client/src/lib/stores/claim.svelte.ts
@@ -69,7 +69,6 @@ export async function claimSingleLand(
     });
 }
 
-
 async function handlePostClaim(
   lands: LandWithActions[],
   result: { nukables: any[]; taxes: any[] },

--- a/client/src/lib/stores/claim.svelte.ts
+++ b/client/src/lib/stores/claim.svelte.ts
@@ -69,7 +69,7 @@ export async function claimSingleLand(
     });
 }
 
-// Agregar esta función helper al inicio del archivo
+
 async function handlePostClaim(
   lands: LandWithActions[],
   result: { nukables: any[]; taxes: any[] },

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -170,3 +170,16 @@ export function ensureNumber(value: BigNumberish) {
     return value;
   }
 }
+
+export function groupLands(lands: LandWithActions[]) {
+  const map = new Map();
+  for (const land of lands) {
+    const key = `${land.token?.name}__${land.token?.address}`;
+    if (!map.has(key)) {
+      map.set(key, []);
+    }
+    map.get(key).push(land);
+  }
+
+  return Array.from(map.entries());
+}


### PR DESCRIPTION
# Improved Land Tax Claiming System

Closes #333, 
Closes #302, 
Closes #232 
![Screenshot 2025-04-20 094153](https://github.com/user-attachments/assets/f7796184-7c78-4dd4-96b7-6d4aa0c629f5)


This PR refactors the land tax claiming functionality by:

1. Moving the "Claim All" button from individual land cards to the toolbar drawer
2. Grouping lands by token type in the toolbar drawer for better organization
3. Implementing batch processing for claiming multiple lands (10 at a time)
4. Creating a reusable `handlePostClaim` helper function to reduce code duplication
5. Adding a utility function to group lands by token

These changes improve the UX by making it easier to claim taxes from multiple lands at once while maintaining the same functionality.