### PR TITLE
center camera on initial load

### DIFF
--- a/client/src/lib/components/map/map.svelte
+++ b/client/src/lib/components/map/map.svelte
@@ -3,13 +3,18 @@
   import type { LandsStore } from '$lib/api/land.svelte';
   import { useLands } from '$lib/api/land.svelte';
   import { useTiles } from '$lib/api/tile-store.svelte';
-  import { cameraPosition, cameraTransition } from '$lib/stores/camera';
+  import {
+    cameraPosition,
+    cameraTransition,
+    moveCameraToLocation,
+  } from '$lib/stores/camera';
   import { claimStore } from '$lib/stores/claim.svelte';
   import { mousePosCoords } from '$lib/stores/stores.svelte';
   import { padAddress } from '$lib/utils';
   import Tile from './tile.svelte';
   import { GRID_SIZE, TILE_SIZE } from '$lib/const';
   import { nukeStore } from '$lib/stores/nuke.svelte';
+  import { onMount } from 'svelte';
 
   // Camera position
   const MIN_SCALE = 0.6;
@@ -31,6 +36,10 @@
   let tileStore = useTiles();
 
   let tiles = $derived($tileStore ?? []);
+
+  onMount(() => {
+    moveCameraToLocation(2080, 3);
+  });
 
   $effect(() => {
     const address = account.address;

--- a/client/src/lib/stores/camera.ts
+++ b/client/src/lib/stores/camera.ts
@@ -47,11 +47,11 @@ export function moveCameraTo(
   });
 }
 
-export function moveCameraToLocation(location: number) {
+export function moveCameraToLocation(location: number, targetScale?: number) {
   const MAP_SIZE = 64;
 
   const tileX = location % MAP_SIZE;
   const tileY = Math.floor(location / MAP_SIZE);
 
-  moveCameraTo(tileX + 1, tileY + 1);
+  moveCameraTo(tileX + 1, tileY + 1, targetScale);
 }


### PR DESCRIPTION
Resolves #332 

# Move camera to a specific location on initial load

This PR adds functionality to automatically move the camera to the center when the map component mounts. It also enhances the `moveCameraToLocation` function to accept an optional `targetScale` parameter, allowing for more control over the zoom level when navigating to a specific location.