### PR TITLE
fix username display

### DIFF
--- a/client/src/lib/components/land/hud/land-hud-other.svelte
+++ b/client/src/lib/components/land/hud/land-hud-other.svelte
@@ -23,11 +23,8 @@
             @TODO: handle in server so we can remove this  
           -->
           {#if $selectedLandMeta?.owner}
-            {usernamesStore.getUsernames()[
-              $selectedLandMeta?.owner
-                ?.replace('0x00', '0x')
-                .replace('0x0', '0x')
-            ] || shortenHex($selectedLandMeta?.owner)}
+            {usernamesStore.getUsernames()[$selectedLandMeta?.owner] ||
+              shortenHex($selectedLandMeta?.owner)}
           {/if}
         </a>
       </p>


### PR DESCRIPTION
# Simplify owner address display in land HUD

Removes unnecessary `0x00` and `0x0` replacements when displaying the land owner's username or shortened hex address in the land HUD component.