### PR TITLE
reduce events storage

### DIFF
--- a/contracts/slot-torii.toml
+++ b/contracts/slot-torii.toml
@@ -15,7 +15,6 @@ historical = [
     "ponzi_land-LandNukedEvent",
 
     "ponzi_land-NewAuctionEvent",
-    "ponzi_land-RemainingStakeEvent",
 
     "ponzi_land-VerifierUpdatedEvent",
 ]

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -424,7 +424,6 @@ pub mod actions {
             assert(land.owner == caller, 'not the owner');
             assert(amount_to_stake > 0, 'amount has to be > 0');
             self.stake._add(amount_to_stake, land, store);
-
         }
 
         fn level_up(ref self: ContractState, land_location: u16) -> bool {
@@ -660,13 +659,7 @@ pub mod actions {
             land.token_used = self.main_currency.read();
 
             store.set_land(land);
-            store
-                .world
-                .emit_event(
-                    @NewAuctionEvent {
-                        land_location, start_price, floor_price,
-                    },
-                );
+            store.world.emit_event(@NewAuctionEvent { land_location, start_price, floor_price });
         }
 
         fn nuke(ref self: ContractState, land_location: u16, has_liquidity_requirements: bool) {

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -158,20 +158,12 @@ pub mod actions {
         token_used: ContractAddress,
     }
 
-    #[derive(Drop, Serde)]
-    #[dojo::event]
-    pub struct RemainingStakeEvent {
-        #[key]
-        land_location: u16,
-        remaining_stake: u256,
-    }
 
     #[derive(Drop, Serde)]
     #[dojo::event]
     pub struct NewAuctionEvent {
         #[key]
         land_location: u16,
-        start_time: u64,
         start_price: u256,
         floor_price: u256,
     }
@@ -182,8 +174,6 @@ pub mod actions {
         #[key]
         land_location: u16,
         buyer: ContractAddress,
-        start_time: u64,
-        final_time: u64,
         final_price: u256,
     }
 
@@ -435,15 +425,6 @@ pub mod actions {
             assert(amount_to_stake > 0, 'amount has to be > 0');
             self.stake._add(amount_to_stake, land, store);
 
-            // Could be removed now that the remaining stake is stored in the world contrect
-            // #52 issue
-            store
-                .world
-                .emit_event(
-                    @RemainingStakeEvent {
-                        land_location: land.location, remaining_stake: land.stake_amount,
-                    },
-                );
         }
 
         fn level_up(ref self: ContractState, land_location: u16) -> bool {
@@ -683,7 +664,7 @@ pub mod actions {
                 .world
                 .emit_event(
                     @NewAuctionEvent {
-                        land_location, start_time: auction.start_time, start_price, floor_price,
+                        land_location, start_price, floor_price,
                     },
                 );
         }
@@ -786,8 +767,6 @@ pub mod actions {
                     @AuctionFinishedEvent {
                         land_location: land.location,
                         buyer: caller,
-                        start_time: auction.start_time,
-                        final_time: get_block_timestamp(),
                         final_price: auction.get_current_price_decay_rate(),
                     },
                 );

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -69,9 +69,6 @@ mod setup {
                 TestResource::Model(m_Land::TEST_CLASS_HASH),
                 TestResource::Model(m_Auction::TEST_CLASS_HASH),
                 TestResource::Contract(actions::TEST_CLASS_HASH),
-                TestResource::Event(
-                    actions::e_RemainingStakeEvent::TEST_CLASS_HASH.try_into().unwrap(),
-                ),
                 TestResource::Event(actions::e_LandNukedEvent::TEST_CLASS_HASH.try_into().unwrap()),
                 TestResource::Event(
                     actions::e_NewAuctionEvent::TEST_CLASS_HASH.try_into().unwrap(),

--- a/contracts/torii-mainnet.toml
+++ b/contracts/torii-mainnet.toml
@@ -15,7 +15,6 @@ historical = [
     "ponzi_land-LandNukedEvent",
 
     "ponzi_land-NewAuctionEvent",
-    "ponzi_land-RemainingStakeEvent",
 
     "ponzi_land-VerifierUpdatedEvent",
 ]


### PR DESCRIPTION
# Remove unnecessary event fields and RemainingStakeEvent

This PR removes the `RemainingStakeEvent` which is no longer needed since the remaining stake is stored in the world contract (as noted in issue #52).

It also simplifies other events by removing redundant fields:
- Removed `start_time` and `final_time` from `AuctionFinishedEvent`
- Removed `start_time` from `NewAuctionEvent`

Updated the corresponding Torii configuration files to reflect these changes.