### PR TITLE
add LandStake model to reduce costs

### DIFF
--- a/contracts/src/helpers/taxes.cairo
+++ b/contracts/src/helpers/taxes.cairo
@@ -1,14 +1,14 @@
 use ponzi_land::utils::level_up::calculate_discount_for_level;
 use ponzi_land::helpers::coord::max_neighbors;
-use ponzi_land::models::land::Land;
+use ponzi_land::models::land::{Land, LandStake};
 use ponzi_land::consts::{TAX_RATE, BASE_TIME, TIME_SPEED};
 use starknet::{get_block_timestamp};
 
-pub fn get_taxes_per_neighbor(land: Land) -> u256 {
+pub fn get_taxes_per_neighbor(land: Land, land_stake: LandStake) -> u256 {
     let current_time = get_block_timestamp();
 
-    //calculate the total taxes
-    let elapsed_time = (current_time - land.last_pay_time) * TIME_SPEED.into();
+    // Calculate the total taxes
+    let elapsed_time = (current_time - land_stake.last_pay_time) * TIME_SPEED.into();
 
     let tax_rate_per_neighbor = get_tax_rate_per_neighbor(land);
 
@@ -33,8 +33,7 @@ pub fn get_tax_rate_per_neighbor(land: Land) -> u256 {
     }
 }
 
-
-pub fn get_time_to_nuke(land: Land, num_neighbors: u8) -> u256 {
+pub fn get_time_to_nuke(land: Land, land_stake: LandStake, num_neighbors: u8) -> u256 {
     let tax_rate_per_neighbor = get_tax_rate_per_neighbor(land);
     let total_tax_rate = tax_rate_per_neighbor * num_neighbors.into();
 
@@ -46,11 +45,11 @@ pub fn get_time_to_nuke(land: Land, num_neighbors: u8) -> u256 {
     // Calculate how many seconds it takes for taxes to equal stake amount
     // The tax accumulation per second is: (total_tax_rate * TIME_SPEED) / (100 * BASE_TIME)
     // So time to nuke = stake_amount / (tax per second)
-    let seconds_to_nuke = (land.stake_amount * 100 * BASE_TIME.into())
+    let seconds_to_nuke = (land_stake.amount * 100 * BASE_TIME.into())
         / (total_tax_rate * TIME_SPEED.into());
 
     // The nuke time is the last payment time plus the seconds until nuke
-    let nuke_time = land.last_pay_time.into() + seconds_to_nuke;
+    let nuke_time = land_stake.last_pay_time.into() + seconds_to_nuke;
 
     let mut res = 0;
     if nuke_time < current_time {

--- a/contracts/src/models/land.cairo
+++ b/contracts/src/models/land.cairo
@@ -15,9 +15,17 @@ pub struct Land {
     pub token_used: ContractAddress,
     pub pool_key: PoolKey, // The Liquidity Pool Key
     //we will use this for taxes
-    pub last_pay_time: u64,
-    pub stake_amount: u256,
     pub level: Level,
+}
+
+
+#[derive(Drop, Serde, Debug, Copy)]
+#[dojo::model]
+pub struct LandStake {
+    #[key]
+    pub location: u16,
+    pub last_pay_time: u64,
+    pub amount: u256,
 }
 
 #[derive(Serde, Drop, Copy, PartialEq, Introspect, Debug)]
@@ -72,9 +80,7 @@ impl LandImpl of LandTrait {
         token_used: ContractAddress,
         sell_price: u256,
         pool_key: PoolKey,
-        last_pay_time: u64,
         block_date_bought: u64,
-        stake_amount: u256,
     ) -> Land {
         Land {
             location,
@@ -82,9 +88,7 @@ impl LandImpl of LandTrait {
             token_used,
             sell_price,
             pool_key,
-            last_pay_time,
             block_date_bought,
-            stake_amount,
             level: Level::Zero,
         }
     }

--- a/contracts/src/store.cairo
+++ b/contracts/src/store.cairo
@@ -1,7 +1,7 @@
 use dojo::world::{WorldStorage};
 use dojo::model::{ModelStorage, ModelValueStorage};
 
-use ponzi_land::models::land::{Land, PoolKey};
+use ponzi_land::models::land::{Land, PoolKey, LandStake};
 use ponzi_land::models::auction::Auction;
 use starknet::contract_address::ContractAddressZeroable;
 
@@ -24,6 +24,11 @@ impl StoreImpl of StoreTrait {
     }
 
     #[inline(always)]
+    fn land_stake(self: Store, land_location: u16) -> LandStake {
+        self.world.read_model(land_location)
+    }
+
+    #[inline(always)]
     fn auction(self: Store, land_location: u16) -> Auction {
         self.world.read_model(land_location)
     }
@@ -32,6 +37,10 @@ impl StoreImpl of StoreTrait {
     #[inline(always)]
     fn set_land(mut self: Store, land: Land) {
         self.world.write_model(@land);
+    }
+
+    fn set_land_stake(mut self: Store, land_stake: LandStake) {
+        self.world.write_model(@land_stake);
     }
 
     #[inline(always)]

--- a/contracts/src/store.cairo
+++ b/contracts/src/store.cairo
@@ -39,6 +39,7 @@ impl StoreImpl of StoreTrait {
         self.world.write_model(@land);
     }
 
+    #[inline(always)]
     fn set_land_stake(mut self: Store, land_stake: LandStake) {
         self.world.write_model(@land_stake);
     }

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -21,7 +21,7 @@ mod setup {
     use ponzi_land::mocks::ekubo_core::{
         MockEkuboCore, IEkuboCoreTesting, IEkuboCoreTestingDispatcher,
     };
-    use ponzi_land::models::land::{Land, m_Land};
+    use ponzi_land::models::land::{Land, m_Land, LandStake, m_LandStake};
     use ponzi_land::models::auction::{Auction, m_Auction};
     use ponzi_land::systems::actions::{actions, IActionsDispatcher, IActionsDispatcherTrait};
     use ponzi_land::systems::auth::{auth, IAuthDispatcher, IAuthDispatcherTrait};
@@ -67,6 +67,7 @@ mod setup {
             namespace: "ponzi_land",
             resources: [
                 TestResource::Model(m_Land::TEST_CLASS_HASH),
+                TestResource::Model(m_LandStake::TEST_CLASS_HASH),
                 TestResource::Model(m_Auction::TEST_CLASS_HASH),
                 TestResource::Contract(actions::TEST_CLASS_HASH),
                 TestResource::Event(actions::e_LandNukedEvent::TEST_CLASS_HASH.try_into().unwrap()),
@@ -120,9 +121,11 @@ mod setup {
             .append(
                 ContractDefTrait::new(@"ponzi_land", @"auth")
                     .with_writer_of([dojo::utils::bytearray_hash(@"ponzi_land")].span())
-                    .with_init_calldata([RECIPIENT().into(), // owner
-                    0.into() // verifier
-                    ].span()),
+                    .with_init_calldata(
+                        [RECIPIENT().into(), // owner
+                        0.into() // verifier
+                        ].span(),
+                    ),
             );
 
         contract_defs.span()

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -121,11 +121,9 @@ mod setup {
             .append(
                 ContractDefTrait::new(@"ponzi_land", @"auth")
                     .with_writer_of([dojo::utils::bytearray_hash(@"ponzi_land")].span())
-                    .with_init_calldata(
-                        [RECIPIENT().into(), // owner
-                        0.into() // verifier
-                        ].span(),
-                    ),
+                    .with_init_calldata([RECIPIENT().into(), // owner
+                    0.into() // verifier
+                    ].span()),
             );
 
         contract_defs.span()


### PR DESCRIPTION
# LandStake model to reduce costs

This PR introduces a new `LandStake` model to separate stake-related data from the main `Land` model. The change moves `stake_amount` and `last_pay_time` fields from `Land` to the new `LandStake` model, which helps reduce gas costs by avoiding unnecessary updates to the main Land model when only stake-related data changes.

Key changes:
- Created new `LandStake` model with `location`, `last_pay_time`, and `amount` fields
- Updated tax calculation functions to work with the new model structure
- Modified stake and tax components to use the new model
- Updated all relevant systems and tests to work with the new data structure

This refactoring improves the contract's efficiency by minimizing state updates during high-frequency operations like tax calculations and stake modifications.