### PR TITLE
fix bug when buy

### DIFF
--- a/client/src/lib/api/land.svelte.ts
+++ b/client/src/lib/api/land.svelte.ts
@@ -199,7 +199,9 @@ export function useLands(): LandsStore | undefined {
           tokenUsed: getTokenInfo(land.token_used)?.name ?? 'Unknown Token',
           tokenAddress: land.token_used,
           stakeAmount: CurrencyAmount.fromUnscaled(landStake?.amount ?? 0),
-          lastPayTime: landStake?.last_pay_time ? Number(landStake.last_pay_time) : 0,
+          lastPayTime: landStake?.last_pay_time
+            ? Number(landStake.last_pay_time)
+            : 0,
           token,
         };
       })

--- a/client/src/lib/api/land.svelte.ts
+++ b/client/src/lib/api/land.svelte.ts
@@ -199,7 +199,7 @@ export function useLands(): LandsStore | undefined {
           tokenUsed: getTokenInfo(land.token_used)?.name ?? 'Unknown Token',
           tokenAddress: land.token_used,
           stakeAmount: CurrencyAmount.fromUnscaled(landStake?.amount ?? 0),
-          lastPayTime: Number(landStake?.last_pay_time) ?? 0,
+          lastPayTime: landStake?.last_pay_time ? Number(landStake.last_pay_time) : 0,
           token,
         };
       })


### PR DESCRIPTION
# Fix land stake last pay time handling

Fixed a bug in the land stake data processing where `lastPayTime` could potentially be set to `NaN` when `landStake?.last_pay_time` is undefined. The updated code properly checks if `last_pay_time` exists before attempting to convert it to a number, defaulting to 0 when the property is missing.