### PR TITLE
fix-modal-when-buy

### DIFF
--- a/client/src/lib/api/land.svelte.ts
+++ b/client/src/lib/api/land.svelte.ts
@@ -377,7 +377,10 @@ export function useLands(): LandsStore | undefined {
         setup.tokenAddress,
         setup.currentPrice!.toBignumberish(),
       );
-      notificationQueue.addNotification(res?.transaction_hash ?? null, 'claim');
+      notificationQueue.addNotification(
+        res?.transaction_hash ?? null,
+        'buy land',
+      );
       return res;
     },
     auctionLand(location, startPrice, floorPrice, decayRate) {

--- a/client/src/lib/components/auction/auction-modal.svelte
+++ b/client/src/lib/components/auction/auction-modal.svelte
@@ -70,15 +70,16 @@
         $selectedLand?.location,
         landSetup,
       );
-
       if (result?.transaction_hash) {
         // Only wait for the land update, not the total TX confirmation (should be fine)
-        await $selectedLand.wait();
+        const txPromise = accountManager!
+          .getProvider()
+          ?.getWalletAccount()
+          ?.waitForTransaction(result.transaction_hash);
+        const landPromise = $selectedLand.wait();
 
+        await Promise.any([txPromise, landPromise]);
         console.log('Bought land with TX: ', result.transaction_hash);
-
-        // Still wait for the tx, just to rollback in the event of an issue
-        notificationQueue.addNotification(result.transaction_hash, 'buy land');
 
         // Close the modal
         uiStore.showModal = false;

--- a/client/src/lib/components/buy/buy-modal.svelte
+++ b/client/src/lib/components/buy/buy-modal.svelte
@@ -72,12 +72,16 @@
 
       if (result?.transaction_hash) {
         // Only wait for the land update, not the total TX confirmation (should be fine)
-        await land.wait();
+        const txPromise = accountManager!
+          .getProvider()
+          ?.getWalletAccount()
+          ?.waitForTransaction(result.transaction_hash);
+        const landPromise = land.wait();
+
+        await Promise.any([txPromise, landPromise]);
 
         console.log('Bought land with TX: ', result.transaction_hash);
 
-        // Still wait for the tx, just to rollback in the event of an issue
-        notificationQueue.addNotification(result.transaction_hash, 'buy land');
 
         // Close the modal
         uiStore.showModal = false;

--- a/client/src/lib/components/buy/buy-modal.svelte
+++ b/client/src/lib/components/buy/buy-modal.svelte
@@ -82,7 +82,6 @@
 
         console.log('Bought land with TX: ', result.transaction_hash);
 
-
         // Close the modal
         uiStore.showModal = false;
         uiStore.modalData = null;


### PR DESCRIPTION
# Improve Land Purchase Transaction Handling

This PR updates the land purchase flow to better handle transaction confirmations:

- Changes notification type from 'claim' to 'buy land' in the land API
- Improves transaction handling in auction and buy modals by using Promise.any to wait for either transaction confirmation or land update
- Removes redundant notification calls in modals since they're already handled in the API