### PR TITLE
fix-increase-stake

### DIFF
--- a/client/src/lib/api/land.svelte.ts
+++ b/client/src/lib/api/land.svelte.ts
@@ -209,13 +209,18 @@ export function useLands(): LandsStore | undefined {
         ...land,
 
         // Add functions
-        increaseStake(amount: CurrencyAmount) {
-          return sdk.client.actions.increaseStake(
+        async increaseStake(amount: CurrencyAmount) {
+          let res = await sdk.client.actions.increaseStake(
             account()?.getWalletAccount()!,
             land.location,
             land.token_used,
             amount.toBignumberish(),
           );
+          notificationQueue.addNotification(
+            res?.transaction_hash ?? null,
+            'increase stake',
+          );
+          return res;
         },
         async wait() {
           // Wait until the land changes


### PR DESCRIPTION
### TL;DR

resolves #441 

Added transaction notification and improved UX for land stake increases.

### What changed?

- Modified `increaseStake` function in `land.svelte.ts` to add transaction notifications
- Enhanced the land info modal to:
  - Properly handle the stake increase flow
  - Add loading state with disabled button during transaction
  - Automatically close the modal after successful transaction
  - Wait for transaction confirmation using `Promise.any` with both transaction and land state changes

### How to test?

1. Open the land info modal
2. Enter an amount to increase stake
3. Click "Increase stake" button
4. Verify that:
   - The button becomes disabled during the transaction
   - A notification appears for the transaction
   - The modal automatically closes after the transaction completes

### Why make this change?

Improves user experience by providing feedback during stake increase transactions and preventing users from submitting multiple transactions while one is in progress. The notification system helps users track their transaction status, and the automatic modal closing creates a smoother workflow.