### PR TITLE
feature-add-increase-price-client

### DIFF
--- a/client/src/lib/api/land.svelte.ts
+++ b/client/src/lib/api/land.svelte.ts
@@ -238,12 +238,17 @@ export function useLands(): LandsStore | undefined {
             15 * 1000, // ms
           );
         },
-        increasePrice(amount: CurrencyAmount) {
-          return sdk.client.actions.increasePrice(
+        async increasePrice(amount: CurrencyAmount) {
+          let res = await sdk.client.actions.increasePrice(
             account()?.getWalletAccount()!,
             land.location,
             amount.toBignumberish(),
           );
+          notificationQueue.addNotification(
+            res?.transaction_hash ?? null,
+            'increase price',
+          );
+          return res;
         },
         async claim() {
           let res = await sdk.client.actions.claim(


### PR DESCRIPTION
### TL;DR

Added the ability to increase land price through the land info modal.

### What changed?

- Added a tab interface in the land info modal to switch between "Increase Stake" and "Increase Price" actions
- Implemented the `increasePrice` functionality in the land API with proper notification handling
- Added validation for price increases to ensure the new price is higher than the current price
- Updated the UI to display appropriate inputs and buttons based on the selected action
- Added error handling and validation for price inputs

### How to test?

1. Open the land info modal for a land you own
2. Switch to the "Increase Price" tab
3. Enter a new price that is higher than the current price
4. Click "Confirm Price" to submit the transaction
5. Verify that a notification appears for the transaction
6. Check that the land's price is updated after the transaction completes

### Why make this change?

This change provides land owners with a more intuitive way to manage their land properties by allowing them to easily increase the selling price directly from the land info modal. Previously, price adjustments were not as accessible, and this improvement streamlines the land management experience.