### PR TITLE
fix claim all

### DIFF
--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -302,7 +302,7 @@ pub mod actions {
                     let land = store.land(land_location);
                     if land.owner != caller {
                         continue;
-                    } 
+                    }
                     self.internal_claim(store, land);
                 }
             };

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -300,7 +300,9 @@ pub mod actions {
                 if !self.active_auction_queue.read(land_location) {
                     assert(is_valid_position(land_location), 'Land location not valid');
                     let land = store.land(land_location);
-                    assert(land.owner == caller, 'not the owner');
+                    if land.owner != caller {
+                        continue;
+                    } 
                     self.internal_claim(store, land);
                 }
             };


### PR DESCRIPTION
# Skip non-owned lands in claim_all

This PR modifies the `claim_all` function to skip lands that are not owned by the caller instead of asserting and failing the entire transaction. This allows users to claim multiple lands even if some of them have changed ownership since the transaction was submitted.