### PR TITLE
change helpers of tax rate

### DIFF
--- a/contracts/src/helpers/taxes.cairo
+++ b/contracts/src/helpers/taxes.cairo
@@ -8,12 +8,11 @@ pub fn get_taxes_per_neighbor(land: Land, land_stake: LandStake) -> u256 {
     let current_time = get_block_timestamp();
 
     // Calculate the total taxes
-    let elapsed_time = (current_time - land_stake.last_pay_time) * TIME_SPEED.into();
+    let elapsed_time = (current_time - land_stake.last_pay_time);
 
     let tax_rate_per_neighbor = get_tax_rate_per_neighbor(land);
 
-    let tax_per_neighbor: u256 = (tax_rate_per_neighbor * elapsed_time.into())
-        / (100 * BASE_TIME.into());
+    let tax_per_neighbor: u256 = (tax_rate_per_neighbor * elapsed_time.into()) / (BASE_TIME.into());
 
     tax_per_neighbor
 }
@@ -25,13 +24,18 @@ pub fn get_tax_rate_per_neighbor(land: Land) -> u256 {
     }
 
     let discount_for_level = calculate_discount_for_level(land.level);
+    let base_tax_rate = (land.sell_price * TAX_RATE.into() * TIME_SPEED.into())
+        / (max_n.into() * 100); // Base rate per neighbor
 
-    if discount_for_level > 0 {
-        land.sell_price * TAX_RATE.into() * (100 - discount_for_level).into() / (max_n.into() * 100)
+    let discounted_tax_rate = if discount_for_level > 0 {
+        (base_tax_rate * (100 - discount_for_level).into()) / 100 // Apply 10% or 15% discount
     } else {
-        land.sell_price * TAX_RATE.into() / (max_n.into())
-    }
+        base_tax_rate
+    };
+
+    discounted_tax_rate
 }
+
 
 pub fn get_time_to_nuke(land: Land, land_stake: LandStake, num_neighbors: u8) -> u256 {
     let tax_rate_per_neighbor = get_tax_rate_per_neighbor(land);
@@ -45,8 +49,7 @@ pub fn get_time_to_nuke(land: Land, land_stake: LandStake, num_neighbors: u8) ->
     // Calculate how many seconds it takes for taxes to equal stake amount
     // The tax accumulation per second is: (total_tax_rate * TIME_SPEED) / (100 * BASE_TIME)
     // So time to nuke = stake_amount / (tax per second)
-    let seconds_to_nuke = (land_stake.amount * 100 * BASE_TIME.into())
-        / (total_tax_rate * TIME_SPEED.into());
+    let seconds_to_nuke = (land_stake.amount * BASE_TIME.into()) / total_tax_rate;
 
     // The nuke time is the last payment time plus the seconds until nuke
     let nuke_time = land_stake.last_pay_time.into() + seconds_to_nuke;

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -537,9 +537,9 @@ pub mod actions {
                     let land_stake = store.land_stake(neighbor.location);
                     if land_stake.amount > 0 {
                         let token = neighbor.token_used;
+                        //TODO: WHY THIS???? remove or fix after playtest
                         let rate = TAX_RATE.into() * TIME_SPEED.into() / 8;
                         let rate_per_hour = get_tax_rate_per_neighbor(neighbor);
-
                         yield_info
                             .append(
                                 YieldInfo {


### PR DESCRIPTION
### TL;DR

Simplified tax calculation logic by removing redundant multiplications and divisions.

### What changed?

- Removed `TIME_SPEED` multiplication from `elapsed_time` calculation in `get_taxes_per_neighbor`
- Simplified the tax calculation formula by removing the redundant `100` division
- Restructured `get_tax_rate_per_neighbor` to calculate a base tax rate first, then apply discounts
- Simplified the `seconds_to_nuke` calculation in `get_time_to_nuke`
- Added a TODO comment in the actions system regarding a tax rate calculation that needs review

### Why make this change?

The previous tax calculation had redundant operations that made the code harder to understand. This change simplifies the formulas while maintaining the same mathematical results, making the code more readable and potentially more gas-efficient by removing unnecessary calculations.