### PR TITLE
fix display burning hour in noob mode

### DIFF
--- a/client/src/lib/components/land/hud/land-hud-info.svelte
+++ b/client/src/lib/components/land/hud/land-hud-info.svelte
@@ -51,10 +51,7 @@
         console.log('tokenPrice', tokenPrice);
         if (tokenPrice) {
           burnRateInBaseToken = CurrencyAmount.fromScaled(
-            burnRate
-              .rawValue()
-              .dividedBy(tokenPrice.ratio || 0)
-              .toString(),
+            burnRate.dividedBy(tokenPrice.ratio || 0).toString(),
             land?.token,
           );
         }


### PR DESCRIPTION
# Fix burn rate calculation in land HUD

Simplifies the burn rate calculation by directly using the `dividedBy` method on the `burnRate` object instead of first calling `rawValue()`.