### PR TITLE
add stake event

### DIFF
--- a/contracts/src/components/stake.cairo
+++ b/contracts/src/components/stake.cairo
@@ -52,7 +52,11 @@ mod StakeComponent {
         impl Payable: PayableComponent::HasComponent<TContractState>,
     > of InternalTrait<TContractState> {
         fn _add(
-            ref self: ComponentState<TContractState>, amount: u256, land: Land, mut store: Store,
+            ref self: ComponentState<TContractState>,
+            amount: u256,
+            land: Land,
+            mut land_stake: LandStake,
+            mut store: Store,
         ) {
             //initialize and validate token balance
             let mut payable = get_dep_component_mut!(ref self, Payable);
@@ -71,7 +75,7 @@ mod StakeComponent {
             self.token_stakes.write(land.token_used, current_total + amount);
 
             //update land stake amount
-            let mut land_stake = store.land_stake(land.location);
+
             land_stake.amount = land_stake.amount + amount;
             land_stake.last_pay_time = get_block_timestamp();
             store.set_land_stake(land_stake);

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -98,6 +98,7 @@ mod setup {
                 TestResource::Event(
                     actions::e_LandBoughtEvent::TEST_CLASS_HASH.try_into().unwrap(),
                 ),
+                TestResource::Event(actions::e_AddStakeEvent::TEST_CLASS_HASH.try_into().unwrap()),
                 TestResource::Contract(auth::TEST_CLASS_HASH),
                 TestResource::Event(
                     auth::e_AddressAuthorizedEvent::TEST_CLASS_HASH.try_into().unwrap(),


### PR DESCRIPTION
### TL;DR

Added an event emission when staking tokens on land and improved the stake component interface.

### What changed?

- Created a new `AddStakeEvent` struct to track staking activity
- Modified the `_add` function in `StakeComponent` to accept a `land_stake` parameter
- Updated the `add_stake` function to emit the new event when tokens are staked
- Updated the `buy_land` function to use the modified stake component interface
- Added the new event to the test setup resources
