### PR TITLE
feat: Use polling instead of subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6219,7 +6219,6 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.27",
  "serde",
  "serde_json",
  "sha2",
@@ -6230,7 +6229,6 @@ dependencies = [
  "tracing",
  "url",
  "uuid 1.17.0",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -40,7 +40,6 @@ http = { workspace = true }
 sqlx = { workspace = true, features = [
     "derive",
     "runtime-tokio",
-    "tls-rustls",
     "postgres",
     "uuid",
     "chrono",

--- a/crates/migrations/main.rs
+++ b/crates/migrations/main.rs
@@ -92,7 +92,7 @@ pub async fn main() {
         Commands::Migrate {} => migrate().await,
         Commands::Add { name } => create_new_migration(name).await,
         Commands::Recreate {} => recreate_database().await,
-    };
+    }
 }
 
 async fn recreate_database() {

--- a/crates/torii-ingester/src/torii_client.rs
+++ b/crates/torii-ingester/src/torii_client.rs
@@ -189,13 +189,13 @@ impl ToriiClient {
     ) -> Result<impl Stream<Item = RawToriiData>, Error> {
         let r#where = r#where.into();
         self.do_request(move |current_offset| {
-            format!(r#"
+            format!(r"
                 SELECT concat( m.namespace, '-', m.name) as selector, e.data as data, e.event_id as event_id, e.created_at as created_at
                 FROM entities_historical e
                 LEFT JOIN models m on e.model_id = m.id
                 WHERE {where}
                 LIMIT 100 OFFSET {current_offset};
-                "#)
+                ")
         })
     }
 
@@ -205,13 +205,13 @@ impl ToriiClient {
     ) -> Result<impl Stream<Item = RawToriiData>, Error> {
         let r#where = r#where.into();
         self.do_request(move |current_offset| {
-            format!(r#"
+            format!(r"
                 SELECT concat(m.namespace, '-',  m.name) as selector, em.data as data, em.event_id as event_id, em.created_at as created_at
                 FROM event_messages_historical em
                 LEFT JOIN models m on em.model_id = m.id
                 WHERE {where}
                 LIMIT 100 OFFSET {current_offset};
-                "#)
+                ")
         })
     }
 

--- a/crates/torii-ingester/src/torii_sql.rs
+++ b/crates/torii-ingester/src/torii_sql.rs
@@ -31,8 +31,9 @@ impl SqlClient {
         let mut url = torii_url
             .into_url()
             .map_err(|e| Error::InvalidUrlError(Some(e)))?;
-        if let Some(segment) = url.path_segments() {
-            if segment.last() != Some("sql") {
+        #[allow(unused_mut)]
+        if let Some(mut segment) = url.path_segments() {
+            if segment.next_back() != Some("sql") {
                 let mut segments = url
                     .path_segments_mut()
                     .map_err(|()| Error::InvalidUrlError(None))?;

--- a/crates/torii-ingester/src/u256.rs
+++ b/crates/torii-ingester/src/u256.rs
@@ -147,7 +147,7 @@ impl<'de> Deserialize<'de> for U256 {
     {
         struct U256Visitor;
 
-        impl<'de> Visitor<'de> for U256Visitor {
+        impl Visitor<'_> for U256Visitor {
             type Value = U256;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/devenv.nix
+++ b/devenv.nix
@@ -18,7 +18,6 @@ in {
     jq
     bc
     colorized-logs
-    openssl
 
     graphite-cli
 
@@ -27,6 +26,8 @@ in {
 
     # Cargo dependencies
     pkg-config
+    openssl
+    gcc
 
     # Depdencies for ledger interconnection
     node-gyp
@@ -90,6 +91,7 @@ in {
 
   services.postgres = {
     enable = true;
+    package = pkgs.postgresql_16;
     initialDatabases = [
       {
         name = "chaindata";


### PR DESCRIPTION
I would have loved to use subscriptions, but as of the current state, it is impossible to get event
IDs in a subscription. As it is the only stable id for any given event, and used to avoid duplication
we are forced to use a polling system, that gets the new events every few seconds.