### PR TITLE
add config contract for consts

### DIFF
--- a/contracts/src/components/stake.cairo
+++ b/contracts/src/components/stake.cairo
@@ -18,7 +18,6 @@ mod StakeComponent {
     // Internal imports
     use ponzi_land::helpers::coord::{max_neighbors};
     use ponzi_land::models::land::{Land, LandStake};
-    use ponzi_land::consts::{TAX_RATE, BASE_TIME, TIME_SPEED, GRID_WIDTH};
     use ponzi_land::store::{Store, StoreTrait};
     use ponzi_land::components::payable::{PayableComponent, IPayable};
     use ponzi_land::utils::{

--- a/contracts/src/consts.cairo
+++ b/contracts/src/consts.cairo
@@ -14,7 +14,7 @@ pub const TWO_DAYS_IN_SECONDS: u32 = 2 * 24 * 60 * 60;
 pub const FOUR_DAYS_IN_SECONDS: u32 = TWO_DAYS_IN_SECONDS * 2;
 pub const LIQUIDITY_SAFETY_MULTIPLIER: u8 = 3;
 pub const MIN_AUCTION_PRICE: u256 = 500 * DECIMALS_FACTOR; // 10
-pub const FACTOR_FOR_SELL_PRICE: u8 = 10; // 10x the sale price at the start
+pub const MIN_AUCTION_PRICE_MULTIPLIER: u8 = 10; // 10x the sale price at the start
 pub const DECIMALS_FACTOR: u256 = 1_000_000_000_000_000_000;
 pub const CENTER_LOCATION: u16 = 2080;
 

--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -2,6 +2,7 @@ mod systems {
     mod actions;
     mod auth;
     mod token_registry;
+    mod config;
 }
 
 mod interfaces {
@@ -11,6 +12,7 @@ mod interfaces {
 mod models {
     mod land;
     mod auction;
+    mod config;
 }
 
 mod helpers {

--- a/contracts/src/models/config.cairo
+++ b/contracts/src/models/config.cairo
@@ -1,0 +1,110 @@
+use starknet::ContractAddress;
+use dojo::world::{WorldStorage};
+use dojo::model::{ModelStorage, ModelValueStorage};
+use ponzi_land::consts::{
+    GRID_WIDTH, TAX_RATE, BASE_TIME, PRICE_DECREASE_RATE, TIME_SPEED, MAX_AUCTIONS,
+    MAX_AUCTIONS_FROM_BID, DECAY_RATE, FLOOR_PRICE, LIQUIDITY_SAFETY_MULTIPLIER, MIN_AUCTION_PRICE,
+    MIN_AUCTION_PRICE_MULTIPLIER, CENTER_LOCATION, AUCTION_DURATION, SCALING_FACTOR,
+    LINEAR_DECAY_TIME, DROP_RATE, RATE_DENOMINATOR,
+};
+
+#[derive(Drop, Serde, Copy, Debug)]
+#[dojo::model]
+pub struct Config {
+    #[key]
+    pub id: u8,
+    pub grid_width: u16,
+    pub tax_rate: u16,
+    pub base_time: u16,
+    pub price_decrease_rate: u16,
+    pub time_speed: u32,
+    pub max_auctions: u8,
+    pub max_auctions_from_bid: u8,
+    pub decay_rate: u16,
+    pub floor_price: u256,
+    pub liquidity_safety_multiplier: u8,
+    pub min_auction_price: u256,
+    pub min_auction_price_multiplier: u8,
+    pub center_location: u16,
+    pub auction_duration: u32,
+    pub scaling_factor: u8,
+    pub linear_decay_time: u16,
+    pub drop_rate: u8,
+    pub rate_denominator: u8,
+}
+
+#[generate_trait]
+impl ConfigImpl of ConfigTrait {
+    #[inline(always)]
+    fn new(
+        id: u8,
+        grid_width: u16,
+        tax_rate: u16,
+        base_time: u16,
+        price_decrease_rate: u16,
+        time_speed: u32,
+        max_auctions: u8,
+        max_auctions_from_bid: u8,
+        decay_rate: u16,
+        floor_price: u256,
+        liquidity_safety_multiplier: u8,
+        min_auction_price: u256,
+        min_auction_price_multiplier: u8,
+        center_location: u16,
+        auction_duration: u32,
+        scaling_factor: u8,
+        linear_decay_time: u16,
+        drop_rate: u8,
+        rate_denominator: u8,
+    ) -> Config {
+        Config {
+            id,
+            grid_width,
+            tax_rate,
+            base_time,
+            price_decrease_rate,
+            time_speed,
+            max_auctions,
+            max_auctions_from_bid,
+            decay_rate,
+            floor_price,
+            liquidity_safety_multiplier,
+            min_auction_price,
+            min_auction_price_multiplier,
+            center_location,
+            auction_duration,
+            scaling_factor,
+            linear_decay_time,
+            drop_rate,
+            rate_denominator,
+        }
+    }
+
+
+    #[inline(always)]
+    fn initialize_default() -> Config {
+        let default_config = Config {
+            id: 1,
+            grid_width: GRID_WIDTH,
+            tax_rate: TAX_RATE,
+            base_time: BASE_TIME,
+            price_decrease_rate: PRICE_DECREASE_RATE,
+            time_speed: TIME_SPEED,
+            max_auctions: MAX_AUCTIONS,
+            max_auctions_from_bid: MAX_AUCTIONS_FROM_BID,
+            decay_rate: DECAY_RATE,
+            floor_price: FLOOR_PRICE,
+            liquidity_safety_multiplier: LIQUIDITY_SAFETY_MULTIPLIER,
+            min_auction_price: MIN_AUCTION_PRICE,
+            min_auction_price_multiplier: MIN_AUCTION_PRICE_MULTIPLIER,
+            center_location: CENTER_LOCATION,
+            auction_duration: AUCTION_DURATION,
+            scaling_factor: SCALING_FACTOR,
+            linear_decay_time: LINEAR_DECAY_TIME,
+            drop_rate: DROP_RATE,
+            rate_denominator: RATE_DENOMINATOR,
+        };
+        default_config
+    }
+}
+

--- a/contracts/src/store.cairo
+++ b/contracts/src/store.cairo
@@ -1,8 +1,9 @@
 use dojo::world::{WorldStorage};
-use dojo::model::{ModelStorage, ModelValueStorage};
+use dojo::model::{ModelStorage, ModelValueStorage, Model};
 
 use ponzi_land::models::land::{Land, PoolKey, LandStake};
 use ponzi_land::models::auction::Auction;
+use ponzi_land::models::config::Config;
 use starknet::contract_address::ContractAddressZeroable;
 
 #[derive(Copy, Drop)]
@@ -55,5 +56,106 @@ impl StoreImpl of StoreTrait {
         //Red: Attempt to see if it is still an issue with torii:
         self.world.erase_model(@land);
         self.world.erase_model(@land_stake);
+    }
+
+    // Config getters
+    #[inline(always)]
+    fn get_grid_width(self: Store) -> u16 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("grid_width"))
+    }
+
+    #[inline(always)]
+    fn get_tax_rate(self: Store) -> u16 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("tax_rate"))
+    }
+
+    #[inline(always)]
+    fn get_base_time(self: Store) -> u16 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("base_time"))
+    }
+
+    #[inline(always)]
+    fn get_price_decrease_rate(self: Store) -> u16 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("price_decrease_rate"))
+    }
+
+    #[inline(always)]
+    fn get_time_speed(self: Store) -> u32 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("time_speed"))
+    }
+
+    #[inline(always)]
+    fn get_max_auctions(self: Store) -> u8 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("max_auctions"))
+    }
+
+    #[inline(always)]
+    fn get_max_auctions_from_bid(self: Store) -> u8 {
+        self
+            .world
+            .read_member(Model::<Config>::ptr_from_keys(1), selector!("max_auctions_from_bid"))
+    }
+
+    #[inline(always)]
+    fn get_decay_rate(self: Store) -> u16 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("decay_rate"))
+    }
+
+    #[inline(always)]
+    fn get_floor_price(self: Store) -> u256 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("floor_price"))
+    }
+
+    #[inline(always)]
+    fn get_liquidity_safety_multiplier(self: Store) -> u8 {
+        self
+            .world
+            .read_member(
+                Model::<Config>::ptr_from_keys(1), selector!("liquidity_safety_multiplier"),
+            )
+    }
+
+    #[inline(always)]
+    fn get_min_auction_price(self: Store) -> u256 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("min_auction_price"))
+    }
+
+    #[inline(always)]
+    fn get_min_auction_price_multiplier(self: Store) -> u8 {
+        self
+            .world
+            .read_member(
+                Model::<Config>::ptr_from_keys(1), selector!("min_auction_price_multiplier"),
+            )
+    }
+
+    #[inline(always)]
+    fn get_center_location(self: Store) -> u16 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("center_location"))
+    }
+
+    #[inline(always)]
+    fn get_auction_duration(self: Store) -> u32 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("auction_duration"))
+    }
+
+    #[inline(always)]
+    fn get_scaling_factor(self: Store) -> u8 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("scaling_factor"))
+    }
+
+    #[inline(always)]
+    fn get_linear_decay_time(self: Store) -> u16 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("linear_decay_time"))
+    }
+
+    #[inline(always)]
+    fn get_drop_rate(self: Store) -> u8 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("drop_rate"))
+    }
+
+    #[inline(always)]
+    fn get_rate_denominator(self: Store) -> u8 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("rate_denominator"))
     }
 }

--- a/contracts/src/systems/config.cairo
+++ b/contracts/src/systems/config.cairo
@@ -1,0 +1,446 @@
+// @notice Configuration system interface for PonziLand.
+// Allows the contract owner to update global economic and gameplay parameters.
+// Each setter updates a specific field in the Config model, which is then used by core game logic
+// in systems such as actions, taxes, and staking.
+#[starknet::interface]
+trait IConfigSystem<T> {
+    
+    /// @notice Sets the grid width, which determines the size of the land map.
+    /// @param value The new grid width (number of tiles per row/column).
+    /// Used throughout the game to validate land positions and compute neighbor relationships (see
+    /// actions.cairo).
+    fn set_grid_width(ref self: T, value: u16);
+
+    /// @notice Sets the tax rate applied to land and transaction operations.
+    /// @param value The new tax rate (percent).
+    /// Used in tax calculation logic in helpers/taxes.cairo and components/taxes.cairo.
+    fn set_tax_rate(ref self: T, value: u16);
+
+    /// @notice Sets the base time parameter, which is used as a reference for time-based mechanics.
+    /// @param value The new base time (in seconds).
+    /// Controls the base time
+    fn set_base_time(ref self: T, value: u16);
+
+    /// @notice Sets the price decrease rate for auctions.
+    /// @param value The new price decrease rate.
+    /// Determines how quickly auction prices decay over time (see auction.cairo).
+    fn set_price_decrease_rate(ref self: T, value: u16);
+
+    /// @notice Sets the global time speed factor.
+    /// @param value The new time speed multiplier.
+    /// Used to accelerate or decelerate all time-based events in the game (affects claims,
+    /// auctions, etc.).
+    fn set_time_speed(ref self: T, value: u32);
+
+    /// @notice Sets the maximum number of auctions allowed simultaneously.
+    /// @param value The new maximum number of concurrent auctions.
+    /// Used to limit auction activity and manage game pacing.
+    fn set_max_auctions(ref self: T, value: u8);
+
+    /// @notice Sets the maximum number of auctions that can be created from a single bid.
+    /// @param value The new maximum auctions from bid.
+    /// Used in advanced auction logic to prevent abuse or excessive expansion.
+    fn set_max_auctions_from_bid(ref self: T, value: u8);
+
+    /// @notice Sets the decay rate for land price or yield.
+    /// @param value The new decay rate.
+    /// Used in land value/yield calculations, affecting how quickly land becomes less valuable if
+    /// unclaimed (see actions.cairo, helpers/taxes.cairo).
+    fn set_decay_rate(ref self: T, value: u16);
+
+    /// @notice Sets the global floor price for auctions and land.
+    /// @param value The new minimum price.
+    /// Ensures that land/auction prices do not fall below a certain threshold.
+    fn set_floor_price(ref self: T, value: u256);
+
+    /// @notice Sets the liquidity safety multiplier, used in staking and liquidity pool
+    /// calculations.
+    /// @param value The new liquidity safety multiplier.
+    /// Used in staking logic to determine minimum required liquidity for actions (see
+    /// components/stake.cairo).
+    fn set_liquidity_safety_multiplier(ref self: T, value: u8);
+
+    /// @notice Sets the minimum auction price.
+    /// @param value The new minimum auction price (as u256).
+    /// Used to prevent auctions from being created with too low a starting price.
+    fn set_min_auction_price(ref self: T, value: u256);
+
+    /// @notice Sets the multiplier used to determine the minimum asking price for new auctions.
+    /// @param value The new multiplier (as an integer).
+    /// This value is used to compute the minimum price for new auctions based on the last sale
+    /// price.
+    /// If the calculated price is below the configured minimum auction price, the minimum is used
+    /// instead.
+    /// This helps prevent underpriced auctions and stabilizes the in-game economy.
+    fn set_min_auction_price_multiplier(ref self: T, value: u8);
+
+    /// @notice Sets the center location of the grid, used for special events or calculations.
+    /// @param value The new center location (tile index).
+    /// Used in expansion logic and initial placement.
+    fn set_center_location(ref self: T, value: u16);
+
+    /// @notice Sets the auction duration.
+    /// @param value The new auction duration (in seconds or ticks).
+    /// Determines how long each auction lasts until become free.
+    fn set_auction_duration(ref self: T, value: u32);
+
+    /// @notice Sets the scaling factor for the auction decay rate.
+    /// @param value The new scaling factor.
+    /// This scales the decay rate (k) in the price decay formula:
+    /// k = (decay_rate * DECIMALS_FACTOR) / scaling_factor
+    fn set_scaling_factor(ref self: T, value: u8);
+
+    /// @notice Sets the initial linear decay period for auction prices.
+    /// @param value The new linear decay time (in seconds).
+    /// During this period, auction prices decrease linearly from start_price.
+    /// After this period, prices follow an exponential decay curve.
+    fn set_linear_decay_time(ref self: T, value: u16);
+
+    /// @notice Sets the drop rate for auction price calculations.
+    /// @param value The new drop rate.
+    /// This parameter determines the percentage of price reduction during the linear decay phase.
+    /// It's used in conjunction with rate_denominator to calculate exact price reductions.
+    fn set_drop_rate(ref self: T, value: u8);
+
+    /// @notice Sets the denominator used in auction price calculations.
+    /// @param value The new rate denominator.
+    /// This parameter is used as the denominator in all auction price calculations.
+    /// It's paired with drop_rate to calculate exact percentages:
+    /// actual_percentage = drop_rate / rate_denominator
+    fn set_rate_denominator(ref self: T, value: u8);
+
+    // Getters
+    fn get_grid_width(self: @T) -> u16;
+    fn get_tax_rate(self: @T) -> u16;
+    fn get_base_time(self: @T) -> u16;
+    fn get_price_decrease_rate(self: @T) -> u16;
+    fn get_time_speed(self: @T) -> u32;
+    fn get_max_auctions(self: @T) -> u8;
+    fn get_max_auctions_from_bid(self: @T) -> u8;
+    fn get_decay_rate(self: @T) -> u16;
+    fn get_floor_price(self: @T) -> u256;
+    fn get_liquidity_safety_multiplier(self: @T) -> u8;
+    fn get_min_auction_price(self: @T) -> u256;
+    fn get_min_auction_price_multiplier(self: @T) -> u8;
+    fn get_center_location(self: @T) -> u16;
+    fn get_auction_duration(self: @T) -> u32;
+    fn get_scaling_factor(self: @T) -> u8;
+    fn get_linear_decay_time(self: @T) -> u16;
+    fn get_drop_rate(self: @T) -> u8;
+    fn get_rate_denominator(self: @T) -> u8;
+}
+
+#[dojo::contract]
+mod config {
+    use super::IConfigSystem;
+    use ponzi_land::models::config::{Config, ConfigTrait};
+    use dojo::world::{WorldStorage};
+    use dojo::model::{ModelStorage, ModelValueStorage, Model};
+    use dojo::event::EventStorage;
+    use starknet::ContractAddress;
+    use starknet::get_caller_address;
+    use ponzi_land::systems::auth::{IAuthDispatcher, IAuthDispatcherTrait};
+    use ponzi_land::interfaces::systems::{SystemsTrait};
+
+
+    #[derive(Drop, Serde)]
+    #[dojo::event]
+    struct ConfigUpdated {
+        #[key]
+        field: felt252,
+        new_value: felt252,
+    }
+
+    fn dojo_init(ref self: ContractState) {
+        let mut world = self.world_default();
+        //initialize default config
+        let init_config: Config = ConfigTrait::initialize_default();
+        world.write_model(@init_config);
+    }
+
+    #[abi(embed_v0)]
+    impl ConfigSystemImpl of IConfigSystem<ContractState> {
+        // Setters
+        fn set_grid_width(ref self: ContractState, value: u16) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world.write_member(Model::<Config>::ptr_from_keys(1), selector!("grid_width"), value);
+            world.emit_event(@ConfigUpdated { field: 'grid_width', new_value: value.into() });
+        }
+
+        fn set_tax_rate(ref self: ContractState, value: u16) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world.write_member(Model::<Config>::ptr_from_keys(1), selector!("tax_rate"), value);
+            world.emit_event(@ConfigUpdated { field: 'tax_rate', new_value: value.into() });
+        }
+
+        fn set_base_time(ref self: ContractState, value: u16) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world.write_member(Model::<Config>::ptr_from_keys(1), selector!("base_time"), value);
+            world.emit_event(@ConfigUpdated { field: 'base_time', new_value: value.into() });
+        }
+
+        fn set_price_decrease_rate(ref self: ContractState, value: u16) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("price_decrease_rate"), value,
+                );
+            world
+                .emit_event(
+                    @ConfigUpdated { field: 'price_decrease_rate', new_value: value.into() },
+                );
+        }
+
+        fn set_time_speed(ref self: ContractState, value: u32) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world.write_member(Model::<Config>::ptr_from_keys(1), selector!("time_speed"), value);
+            world.emit_event(@ConfigUpdated { field: 'time_speed', new_value: value.into() });
+        }
+
+        fn set_max_auctions(ref self: ContractState, value: u8) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world.write_member(Model::<Config>::ptr_from_keys(1), selector!("max_auctions"), value);
+            world.emit_event(@ConfigUpdated { field: 'max_auctions', new_value: value.into() });
+        }
+
+        fn set_max_auctions_from_bid(ref self: ContractState, value: u8) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("max_auctions_from_bid"), value,
+                );
+            world
+                .emit_event(
+                    @ConfigUpdated { field: 'max_auctions_from_bid', new_value: value.into() },
+                );
+        }
+
+        fn set_decay_rate(ref self: ContractState, value: u16) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world.write_member(Model::<Config>::ptr_from_keys(1), selector!("decay_rate"), value);
+            world.emit_event(@ConfigUpdated { field: 'decay_rate', new_value: value.into() });
+        }
+
+        fn set_floor_price(ref self: ContractState, value: u256) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world.write_member(Model::<Config>::ptr_from_keys(1), selector!("floor_price"), value);
+            world
+                .emit_event(
+                    @ConfigUpdated { field: 'floor_price', new_value: value.try_into().unwrap() },
+                );
+        }
+
+        fn set_liquidity_safety_multiplier(ref self: ContractState, value: u8) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1),
+                    selector!("liquidity_safety_multiplier"),
+                    value,
+                );
+            world
+                .emit_event(
+                    @ConfigUpdated {
+                        field: 'liquidity_safety_multiplier', new_value: value.into(),
+                    },
+                );
+        }
+
+        fn set_min_auction_price(ref self: ContractState, value: u256) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("min_auction_price"), value,
+                );
+            world
+                .emit_event(
+                    @ConfigUpdated {
+                        field: 'min_auction_price', new_value: value.try_into().unwrap(),
+                    },
+                );
+        }
+
+        fn set_min_auction_price_multiplier(ref self: ContractState, value: u8) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1),
+                    selector!("min_auction_price_multiplier"),
+                    value,
+                );
+            world
+                .emit_event(
+                    @ConfigUpdated {
+                        field: 'min_auction_price_multiplier', new_value: value.into(),
+                    },
+                );
+        }
+
+        fn set_center_location(ref self: ContractState, value: u16) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("center_location"), value,
+                );
+            world.emit_event(@ConfigUpdated { field: 'center_location', new_value: value.into() });
+        }
+
+        fn set_auction_duration(ref self: ContractState, value: u32) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("auction_duration"), value,
+                );
+            world.emit_event(@ConfigUpdated { field: 'auction_duration', new_value: value.into() });
+        }
+
+        fn set_scaling_factor(ref self: ContractState, value: u8) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("scaling_factor"), value,
+                );
+            world.emit_event(@ConfigUpdated { field: 'scaling_factor', new_value: value.into() });
+        }
+
+        fn set_linear_decay_time(ref self: ContractState, value: u16) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("linear_decay_time"), value,
+                );
+            world
+                .emit_event(@ConfigUpdated { field: 'linear_decay_time', new_value: value.into() });
+        }
+
+        fn set_drop_rate(ref self: ContractState, value: u8) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world.write_member(Model::<Config>::ptr_from_keys(1), selector!("drop_rate"), value);
+            world.emit_event(@ConfigUpdated { field: 'drop_rate', new_value: value.into() });
+        }
+
+        fn set_rate_denominator(ref self: ContractState, value: u8) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("rate_denominator"), value,
+                );
+            world.emit_event(@ConfigUpdated { field: 'rate_denominator', new_value: value.into() });
+        }
+
+        // Getters implementation
+        fn get_grid_width(self: @ContractState) -> u16 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("grid_width"))
+        }
+
+        fn get_tax_rate(self: @ContractState) -> u16 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("tax_rate"))
+        }
+
+        fn get_base_time(self: @ContractState) -> u16 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("base_time"))
+        }
+
+        fn get_price_decrease_rate(self: @ContractState) -> u16 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("price_decrease_rate"))
+        }
+
+        fn get_time_speed(self: @ContractState) -> u32 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("time_speed"))
+        }
+
+        fn get_max_auctions(self: @ContractState) -> u8 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("max_auctions"))
+        }
+
+        fn get_max_auctions_from_bid(self: @ContractState) -> u8 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("max_auctions_from_bid"))
+        }
+
+        fn get_decay_rate(self: @ContractState) -> u16 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("decay_rate"))
+        }
+
+        fn get_floor_price(self: @ContractState) -> u256 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("floor_price"))
+        }
+
+        fn get_liquidity_safety_multiplier(self: @ContractState) -> u8 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("liquidity_safety_multiplier"))
+        }
+
+        fn get_min_auction_price(self: @ContractState) -> u256 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("min_auction_price"))
+        }
+
+        fn get_min_auction_price_multiplier(self: @ContractState) -> u8 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("min_auction_price_multiplier"))
+        }
+
+        fn get_center_location(self: @ContractState) -> u16 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("center_location"))
+        }
+
+        fn get_auction_duration(self: @ContractState) -> u32 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("auction_duration"))
+        }
+
+        fn get_scaling_factor(self: @ContractState) -> u8 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("scaling_factor"))
+        }
+
+        fn get_linear_decay_time(self: @ContractState) -> u16 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("linear_decay_time"))
+        }
+
+        fn get_drop_rate(self: @ContractState) -> u8 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("drop_rate"))
+        }
+
+        fn get_rate_denominator(self: @ContractState) -> u8 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("rate_denominator"))
+        }
+    }
+    #[generate_trait]
+    impl InternalFunctions of InternalFunctionsTrait {
+        fn world_default(self: @ContractState) -> WorldStorage {
+            self.world(@"ponzi_land")
+        }
+    }
+}

--- a/contracts/src/systems/config.cairo
+++ b/contracts/src/systems/config.cairo
@@ -4,7 +4,6 @@
 // in systems such as actions, taxes, and staking.
 #[starknet::interface]
 trait IConfigSystem<T> {
-    
     /// @notice Sets the grid width, which determines the size of the land map.
     /// @param value The new grid width (number of tiles per row/column).
     /// Used throughout the game to validate land positions and compute neighbor relationships (see
@@ -394,7 +393,10 @@ mod config {
 
         fn get_liquidity_safety_multiplier(self: @ContractState) -> u8 {
             let world = self.world_default();
-            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("liquidity_safety_multiplier"))
+            world
+                .read_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("liquidity_safety_multiplier"),
+                )
         }
 
         fn get_min_auction_price(self: @ContractState) -> u256 {
@@ -404,7 +406,10 @@ mod config {
 
         fn get_min_auction_price_multiplier(self: @ContractState) -> u8 {
             let world = self.world_default();
-            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("min_auction_price_multiplier"))
+            world
+                .read_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("min_auction_price_multiplier"),
+                )
         }
 
         fn get_center_location(self: @ContractState) -> u16 {

--- a/contracts/src/tests/actions.cairo
+++ b/contracts/src/tests/actions.cairo
@@ -293,7 +293,7 @@ fn setup_test() -> (
     IEkuboCoreTestingDispatcher,
     ITokenRegistryDispatcher,
 ) {
-    let (world, actions_system, erc20, _, testing_dispatcher, auth_system, token_registry) =
+    let (world, actions_system, erc20, _, testing_dispatcher, auth_system, token_registry, _) =
         create_setup();
     set_contract_address(RECIPIENT());
     // Setup authorization

--- a/contracts/src/utils/get_neighbors.cairo
+++ b/contracts/src/utils/get_neighbors.cairo
@@ -1,4 +1,3 @@
-use ponzi_land::consts::{MIN_AUCTION_PRICE, FACTOR_FOR_SELL_PRICE};
 use ponzi_land::store::{Store, StoreTrait};
 use ponzi_land::models::land::Land;
 use ponzi_land::models::auction::Auction;
@@ -68,7 +67,7 @@ fn get_average_price(mut store: Store, land_location: u16) -> u256 {
     let neighbors = get_auction_neighbors(store, land_location);
 
     if neighbors.len() == 0 {
-        return MIN_AUCTION_PRICE;
+        return store.get_min_auction_price();
     };
 
     let mut total_price = 0;
@@ -78,7 +77,7 @@ fn get_average_price(mut store: Store, land_location: u16) -> u256 {
         total_price += neighbor.sold_at_price.unwrap();
         i += 1;
     };
-    (total_price / neighbors.len().into()) * FACTOR_FOR_SELL_PRICE.into()
+    (total_price / neighbors.len().into()) * store.get_min_auction_price_multiplier().into()
 }
 
 fn get_directions(land_location: u16) -> Array<Option<u16>> {

--- a/contracts/src/utils/spiral.cairo
+++ b/contracts/src/utils/spiral.cairo
@@ -3,7 +3,6 @@ use ponzi_land::helpers::coord::{
     down_right,
 };
 use ponzi_land::store::{Store, StoreTrait};
-use ponzi_land::consts::{MAX_AUCTIONS};
 use starknet::storage::{
     Map, StoragePointerReadAccess, StoragePointerWriteAccess, Vec, VecTrait, MutableVecTrait,
 };


### PR DESCRIPTION
### TL;DR

Implemented a configurable game parameters system to replace hardcoded constants, making the game more flexible and easier to tune.

### What changed?

- Created a new `Config` model to store all game parameters that were previously hardcoded constants
- Added a new `config.cairo` system with setters and getters for all parameters
- Modified functions across the codebase to read parameters from the store instead of using constants
- Added proper parameter passing to functions that need configuration values
- Renamed `FACTOR_FOR_SELL_PRICE` to `MIN_AUCTION_PRICE_MULTIPLIER` for clarity
- Updated tests to work with the new configuration system

### Why make this change?

This change provides several benefits:
- Allows game parameters to be adjusted without redeploying contracts
- Makes the game more adaptable to economic conditions and player feedback
- Enables fine-tuning of game mechanics for better balance
- Improves maintainability by centralizing configuration
- Provides better control for the game owner to respond to emergent gameplay patterns