### PR TITLE
add fees for claim and buy

### DIFF
--- a/contracts/.tool-versions
+++ b/contracts/.tool-versions
@@ -1,3 +1,3 @@
-dojo 1.4.0
+dojo 1.6.0-alpha.2
 cairo 2.9.4
-scarb 2.9.4
+scarb 2.10.1

--- a/contracts/src/components/payable.cairo
+++ b/contracts/src/components/payable.cairo
@@ -38,13 +38,6 @@ trait IPayable<TContractState> {
         validation_result: ValidationResult,
     ) -> bool;
 
-    fn proccess_payment_with_fee_for_claim(
-        self: @TContractState,
-        claimer: ContractAddress,
-        fee_rate: u128,
-        our_contract_for_fee: ContractAddress,
-        validation_result: ValidationResult,
-    ) -> bool;
 
     fn balance_of(
         ref self: TContractState, token_address: ContractAddress, owner: ContractAddress,

--- a/contracts/src/components/taxes.cairo
+++ b/contracts/src/components/taxes.cairo
@@ -24,13 +24,14 @@ mod TaxesComponent {
     use ponzi_land::helpers::coord::max_neighbors;
     use ponzi_land::models::land::{Land, LandStake};
     use ponzi_land::store::{Store, StoreTrait};
-    use ponzi_land::components::payable::{PayableComponent, IPayable};
+    use ponzi_land::components::payable::{PayableComponent, IPayable, ValidationResult};
     use ponzi_land::utils::common_strucs::{TokenInfo};
     use ponzi_land::utils::math::{u64_saturating_sub};
     use ponzi_land::utils::packing::{pack_neighbors_info, unpack_neighbors_info};
     use ponzi_land::helpers::land::{add_neighbor, remove_neighbor};
     use ponzi_land::helpers::taxes::{
         get_taxes_per_neighbor, get_tax_rate_per_neighbor, calculate_share_for_nuke,
+        calculate_and_return_taxes_with_fee,
     };
     use ponzi_land::utils::get_neighbors::get_land_neighbors;
 
@@ -106,6 +107,7 @@ mod TaxesComponent {
             current_time: u64,
             our_contract_address: ContractAddress,
             claim_fee: u128,
+            claim_fee_threshold: u128,
             our_contract_for_fee: ContractAddress,
         ) -> bool {
             let (
@@ -129,7 +131,13 @@ mod TaxesComponent {
                     .get_elapsed_time_since_last_claim(
                         *claimer.location, *tax_payer.location, current_time,
                     );
-                let tax_for_claimer = get_taxes_per_neighbor(tax_payer, elapsed_time, store);
+
+                let total_taxes = get_taxes_per_neighbor(tax_payer, elapsed_time, store);
+
+                let (tax_for_claimer, fee_amount) = calculate_and_return_taxes_with_fee(
+                    total_taxes, claim_fee,
+                );
+                payer_stake.accumulated_taxes_fee += fee_amount;
                 self
                     ._execute_claim(
                         store,
@@ -139,8 +147,8 @@ mod TaxesComponent {
                         tax_for_claimer,
                         ref payer_stake,
                         current_time,
+                        claim_fee_threshold,
                         our_contract_address,
-                        claim_fee,
                         our_contract_for_fee,
                     );
 
@@ -153,13 +161,12 @@ mod TaxesComponent {
                             ref payer_stake,
                             neighbors_of_tax_payer,
                             current_time,
-                            tax_for_claimer,
+                            total_taxes,
                         );
                 } else {
-                    payer_stake.amount -= tax_for_claimer;
+                    payer_stake.amount -= total_taxes;
                     store.set_land_stake(payer_stake);
                 }
-
                 return false;
             } else {
                 let neighbors_of_tax_payer = get_land_neighbors(store, *tax_payer.location);
@@ -174,11 +181,13 @@ mod TaxesComponent {
                         current_time,
                         our_contract_address,
                         claim_fee,
+                        claim_fee_threshold,
                         our_contract_for_fee,
                     );
                 is_nuke
             }
         }
+
         fn _calculate_taxes_and_verify_nuke(
             ref self: ComponentState<TContractState>,
             store: Store,
@@ -190,9 +199,10 @@ mod TaxesComponent {
             current_time: u64,
             our_contract_address: ContractAddress,
             claim_fee: u128,
+            claim_fee_threshold: u128,
             our_contract_for_fee: ContractAddress,
         ) -> bool {
-            let (total_taxes, tax_for_claimer, cache_elapased_time, total_elapsed_time) = self
+            let (total_taxes, total_tax_for_claimer, cache_elapased_time, total_elapsed_time) = self
                 ._calculate_taxes_for_all_neighbors(
                     claimer,
                     tax_payer,
@@ -206,11 +216,12 @@ mod TaxesComponent {
                     ._handle_nuke(
                         store,
                         tax_payer,
-                        payer_stake.amount,
+                        ref payer_stake,
                         cache_elapased_time,
                         total_elapsed_time,
                         our_contract_address,
                         claim_fee,
+                        claim_fee_threshold,
                         our_contract_for_fee,
                     );
 
@@ -227,6 +238,7 @@ mod TaxesComponent {
                             current_time,
                             our_contract_address,
                             claim_fee,
+                            claim_fee_threshold,
                             our_contract_for_fee,
                         );
                     store.set_land_stake(neghbor_stake);
@@ -236,6 +248,10 @@ mod TaxesComponent {
 
                 true
             } else {
+                let (tax_for_claimer, fee_amount) = calculate_and_return_taxes_with_fee(
+                    total_tax_for_claimer, claim_fee,
+                );
+                payer_stake.accumulated_taxes_fee += fee_amount;
                 self
                     ._execute_claim(
                         store,
@@ -245,8 +261,8 @@ mod TaxesComponent {
                         tax_for_claimer,
                         ref payer_stake,
                         current_time,
+                        claim_fee_threshold,
                         our_contract_address,
-                        claim_fee,
                         our_contract_for_fee,
                     );
                 if *claimer.location == earliest_claimer_location {
@@ -257,10 +273,10 @@ mod TaxesComponent {
                             ref payer_stake,
                             neighbors_of_tax_payer,
                             current_time,
-                            tax_for_claimer,
+                            total_tax_for_claimer,
                         );
                 } else {
-                    payer_stake.amount -= tax_for_claimer;
+                    payer_stake.amount -= total_tax_for_claimer;
                     store.set_land_stake(payer_stake);
                 }
 
@@ -272,29 +288,35 @@ mod TaxesComponent {
             ref self: ComponentState<TContractState>,
             store: Store,
             tax_payer: @Land,
-            tax_payer_stake_amount: u256,
+            ref tax_payer_stake: LandStake,
             cache_elapased_time: Array<(u16, ContractAddress, u64)>,
             total_elapsed_time: u64,
             our_contract_address: ContractAddress,
             claim_fee: u128,
+            claim_fee_threshold: u128,
             our_contract_for_fee: ContractAddress,
         ) {
             let mut tax_amount_for_neighbor: Array<(u16, ContractAddress, u256)> =
                 ArrayTrait::new();
             for (location, neighbor_address, elapsed_time) in cache_elapased_time {
                 let share_for_neighbor = calculate_share_for_nuke(
-                    elapsed_time, total_elapsed_time, tax_payer_stake_amount,
+                    elapsed_time, total_elapsed_time, tax_payer_stake.amount,
                 );
+                let (share_for_neighbor, fee_amount) = calculate_and_return_taxes_with_fee(
+                    share_for_neighbor, claim_fee,
+                );
+                tax_payer_stake.accumulated_taxes_fee += fee_amount;
                 tax_amount_for_neighbor.append((location, neighbor_address, share_for_neighbor));
             };
 
             self
                 ._distribute_nuke(
                     store,
-                    @*tax_payer,
+                    tax_payer,
+                    ref tax_payer_stake,
                     tax_amount_for_neighbor.span(),
                     our_contract_address,
-                    claim_fee,
+                    claim_fee_threshold,
                     our_contract_for_fee,
                 );
         }
@@ -380,9 +402,10 @@ mod TaxesComponent {
             ref self: ComponentState<TContractState>,
             store: Store,
             nuked_land: @Land,
+            ref nuked_land_stake: LandStake,
             neighbors_of_nuked_land: Span<(u16, ContractAddress, u256)>,
             our_contract_address: ContractAddress,
-            claim_fee: u128,
+            claim_fee_threshold: u128,
             our_contract_for_fee: ContractAddress,
         ) {
             for (neighbor_location, neighbor_address, tax_amount) in neighbors_of_nuked_land {
@@ -391,9 +414,11 @@ mod TaxesComponent {
                         *neighbor_address,
                         *nuked_land.owner,
                         TokenInfo { token_address: *nuked_land.token_used, amount: *tax_amount },
+                        ref nuked_land_stake,
+                        claim_fee_threshold,
                         our_contract_address,
-                        claim_fee,
                         our_contract_for_fee,
+                        true,
                     );
                 if let Option::Some(updated_stake) =
                     remove_neighbor(store.land_stake(*neighbor_location)) {
@@ -408,21 +433,42 @@ mod TaxesComponent {
             tax_receiver: ContractAddress,
             tax_payer: ContractAddress,
             token_info: TokenInfo,
+            ref land_stake: LandStake,
+            claim_fee_threshold: u128,
             our_contract_address: ContractAddress,
-            claim_fee: u128,
             our_contract_for_fee: ContractAddress,
+            from_nuke: bool,
         ) {
             let mut payable = get_dep_component_mut!(ref self, Payable);
+            let total_amount_to_validate = token_info.amount
+                + land_stake.accumulated_taxes_fee.into();
             let validation_result = payable
-                .validate(token_info.token_address, our_contract_address, token_info.amount);
+                .validate(token_info.token_address, our_contract_address, total_amount_to_validate);
 
-            let status = payable
-                .proccess_payment_with_fee_for_claim(
-                    tax_receiver, claim_fee, our_contract_for_fee, validation_result,
-                );
+            let validation_result_for_fees = ValidationResult {
+                status: validation_result.status,
+                token_address: validation_result.token_address,
+                amount: land_stake.accumulated_taxes_fee.into(),
+            };
+            let validation_result_for_claim = ValidationResult {
+                status: validation_result.status,
+                token_address: validation_result.token_address,
+                amount: token_info.amount,
+            };
 
-            // let status = payable.transfer(tax_receiver, validation_result);
-            assert(status, errors::ERC20_TRANSFER_CLAIM_FAILED);
+            let mut status_for_transfer_fee = true;
+            if from_nuke && land_stake.accumulated_taxes_fee > 0 {
+                status_for_transfer_fee = payable
+                    .transfer(our_contract_for_fee, validation_result_for_fees);
+                land_stake.accumulated_taxes_fee = 0;
+            } else if land_stake.accumulated_taxes_fee >= claim_fee_threshold {
+                status_for_transfer_fee = payable
+                    .transfer(our_contract_for_fee, validation_result_for_fees);
+                land_stake.accumulated_taxes_fee = 0;
+            }
+
+            let status = payable.transfer(tax_receiver, validation_result_for_claim);
+            assert(status && status_for_transfer_fee, errors::ERC20_TRANSFER_CLAIM_FAILED);
         }
 
         /// Executes the actual claim of taxes
@@ -436,8 +482,8 @@ mod TaxesComponent {
             available_tax_for_claimer: u256,
             ref land_stake: LandStake,
             current_time: u64,
+            claim_fee_threshold: u128,
             our_contract_address: ContractAddress,
-            claim_fee: u128,
             our_contract_for_fee: ContractAddress,
         ) {
             if available_tax_for_claimer > 0 && available_tax_for_claimer < land_stake.amount {
@@ -448,9 +494,11 @@ mod TaxesComponent {
                         TokenInfo {
                             token_address: *tax_payer.token_used, amount: available_tax_for_claimer,
                         },
+                        ref land_stake,
+                        claim_fee_threshold,
                         our_contract_address,
-                        claim_fee,
                         our_contract_for_fee,
+                        false,
                     );
 
                 store

--- a/contracts/src/consts.cairo
+++ b/contracts/src/consts.cairo
@@ -1,3 +1,14 @@
+//! This file contains default configuration values used EXCLUSIVELY for testing purposes.
+//! These values are not used directly by the contract during runtime.
+//!
+//! The actual configuration values are stored in the on-chain `Config` model and can be modified
+//! by the contract owner through the configuration system. These test constants are only used to:
+//! 1. Initialize the contract in test environments
+//! 2. Provide default values for test cases
+//! 3. Serve as reference for expected value ranges
+//!
+//! To modify these values in production, use the configuration system's update methods.
+
 pub const GRID_WIDTH: u8 = 64;
 pub const MAX_GRID_SIZE: u8 = 255;
 
@@ -19,12 +30,14 @@ pub const MIN_AUCTION_PRICE: u256 = 500 * DECIMALS_FACTOR; // 10
 pub const MIN_AUCTION_PRICE_MULTIPLIER: u8 = 10; // 10x the sale price at the start
 pub const DECIMALS_FACTOR: u256 = 1_000_000_000_000_000_000;
 pub const CENTER_LOCATION: u16 = 32639;
-pub const MAX_CIRCLES: u16 = 64;
+pub const MAX_CIRCLES: u16 = 127;
 
 
 pub const SCALE_FACTOR_FOR_FEE: u128 = 10_000_000;
 pub const CLAIM_FEE: u128 = 900_000;
 pub const BUY_FEE: u128 = 990_000;
+// 10 is for easier tests
+pub const CLAIM_FEE_THRESHOLD: u128 = 10; //1_000_000_000_000_000; // 1e15
 pub const OUR_CONTRACT_FOR_FEE: felt252 =
     0x021fBAE9F9343873ab25eC14d287A1170b676C73c97906790ef91F5428dBdbac;
 

--- a/contracts/src/consts.cairo
+++ b/contracts/src/consts.cairo
@@ -21,6 +21,13 @@ pub const DECIMALS_FACTOR: u256 = 1_000_000_000_000_000_000;
 pub const CENTER_LOCATION: u16 = 32639;
 pub const MAX_CIRCLES: u16 = 64;
 
+
+pub const SCALE_FACTOR_FOR_FEE: u128 = 10_000_000;
+pub const CLAIM_FEE: u128 = 900_000;
+pub const BUY_FEE: u128 = 990_000;
+pub const OUR_CONTRACT_FOR_FEE: felt252 =
+    0x021fBAE9F9343873ab25eC14d287A1170b676C73c97906790ef91F5428dBdbac;
+
 const AUCTION_DURATION: u32 = 7 * 24 * 60 * 60; // 1 week in seconds
 
 const SCALING_FACTOR: u8 = 50;

--- a/contracts/src/helpers/taxes.cairo
+++ b/contracts/src/helpers/taxes.cairo
@@ -2,7 +2,7 @@ use ponzi_land::utils::level_up::calculate_discount_for_level;
 use ponzi_land::helpers::coord::max_neighbors;
 use ponzi_land::models::land::{Land, LandStake};
 use ponzi_land::store::{Store, StoreTrait};
-use ponzi_land::consts::{DECIMALS_FACTOR};
+use ponzi_land::consts::{DECIMALS_FACTOR, SCALE_FACTOR_FOR_FEE};
 use starknet::{get_block_timestamp};
 
 
@@ -48,3 +48,13 @@ fn calculate_share_for_nuke(
     scaled_share / DECIMALS_FACTOR
 }
 
+
+//TODO: here also we can pass a ref of landStake and after do only 1 write with everything updated
+#[inline(always)]
+pub fn calculate_and_return_taxes_with_fee(
+    total_taxes_amount: u256, fee_rate: u128,
+) -> (u256, u128) {
+    let fee_amount = total_taxes_amount * fee_rate.into() / SCALE_FACTOR_FOR_FEE.into();
+    let amount_for_claimer = total_taxes_amount - fee_amount;
+    (amount_for_claimer, fee_amount.try_into().unwrap())
+}

--- a/contracts/src/models/config.cairo
+++ b/contracts/src/models/config.cairo
@@ -5,7 +5,8 @@ use ponzi_land::consts::{
     GRID_WIDTH, TAX_RATE, BASE_TIME, PRICE_DECREASE_RATE, TIME_SPEED, MAX_AUCTIONS,
     MAX_AUCTIONS_FROM_BID, DECAY_RATE, FLOOR_PRICE, LIQUIDITY_SAFETY_MULTIPLIER, MIN_AUCTION_PRICE,
     MIN_AUCTION_PRICE_MULTIPLIER, CENTER_LOCATION, AUCTION_DURATION, SCALING_FACTOR,
-    LINEAR_DECAY_TIME, DROP_RATE, RATE_DENOMINATOR, MAX_CIRCLES,
+    LINEAR_DECAY_TIME, DROP_RATE, RATE_DENOMINATOR, MAX_CIRCLES, CLAIM_FEE, BUY_FEE,
+    OUR_CONTRACT_SEPOLIA_ADDRESS,
 };
 
 #[derive(Drop, Serde, Copy, Debug)]
@@ -32,6 +33,10 @@ pub struct Config {
     pub drop_rate: u8,
     pub rate_denominator: u8,
     pub max_circles: u16,
+    pub claim_fee: u128,
+    pub buy_fee: u128,
+    pub our_contract_for_fee: ContractAddress,
+    pub our_contract_for_auction: ContractAddress,
 }
 
 #[generate_trait]
@@ -57,6 +62,10 @@ impl ConfigImpl of ConfigTrait {
         drop_rate: u8,
         rate_denominator: u8,
         max_circles: u16,
+        claim_fee: u128,
+        buy_fee: u128,
+        our_contract_for_fee: ContractAddress,
+        our_contract_for_auction: ContractAddress,
     ) -> Config {
         Config {
             id: 1,
@@ -79,6 +88,10 @@ impl ConfigImpl of ConfigTrait {
             drop_rate,
             rate_denominator,
             max_circles,
+            claim_fee,
+            buy_fee,
+            our_contract_for_fee,
+            our_contract_for_auction,
         }
     }
 
@@ -106,6 +119,10 @@ impl ConfigImpl of ConfigTrait {
             drop_rate: DROP_RATE,
             rate_denominator: RATE_DENOMINATOR,
             max_circles: MAX_CIRCLES,
+            claim_fee: CLAIM_FEE,
+            buy_fee: BUY_FEE,
+            our_contract_for_fee: OUR_CONTRACT_SEPOLIA_ADDRESS.try_into().unwrap(),
+            our_contract_for_auction: OUR_CONTRACT_SEPOLIA_ADDRESS.try_into().unwrap(),
         };
         default_config
     }

--- a/contracts/src/models/config.cairo
+++ b/contracts/src/models/config.cairo
@@ -6,7 +6,7 @@ use ponzi_land::consts::{
     MAX_AUCTIONS_FROM_BID, DECAY_RATE, FLOOR_PRICE, LIQUIDITY_SAFETY_MULTIPLIER, MIN_AUCTION_PRICE,
     MIN_AUCTION_PRICE_MULTIPLIER, CENTER_LOCATION, AUCTION_DURATION, SCALING_FACTOR,
     LINEAR_DECAY_TIME, DROP_RATE, RATE_DENOMINATOR, MAX_CIRCLES, CLAIM_FEE, BUY_FEE,
-    OUR_CONTRACT_SEPOLIA_ADDRESS,
+    OUR_CONTRACT_SEPOLIA_ADDRESS, CLAIM_FEE_THRESHOLD,
 };
 
 #[derive(Drop, Serde, Copy, Debug)]
@@ -37,6 +37,7 @@ pub struct Config {
     pub buy_fee: u128,
     pub our_contract_for_fee: ContractAddress,
     pub our_contract_for_auction: ContractAddress,
+    pub claim_fee_threshold: u128,
 }
 
 #[generate_trait]
@@ -66,6 +67,7 @@ impl ConfigImpl of ConfigTrait {
         buy_fee: u128,
         our_contract_for_fee: ContractAddress,
         our_contract_for_auction: ContractAddress,
+        claim_fee_threshold: u128,
     ) -> Config {
         Config {
             id: 1,
@@ -92,6 +94,7 @@ impl ConfigImpl of ConfigTrait {
             buy_fee,
             our_contract_for_fee,
             our_contract_for_auction,
+            claim_fee_threshold,
         }
     }
 
@@ -123,6 +126,7 @@ impl ConfigImpl of ConfigTrait {
             buy_fee: BUY_FEE,
             our_contract_for_fee: OUR_CONTRACT_SEPOLIA_ADDRESS.try_into().unwrap(),
             our_contract_for_auction: OUR_CONTRACT_SEPOLIA_ADDRESS.try_into().unwrap(),
+            claim_fee_threshold: CLAIM_FEE_THRESHOLD,
         };
         default_config
     }

--- a/contracts/src/models/land.cairo
+++ b/contracts/src/models/land.cairo
@@ -21,6 +21,7 @@ pub struct LandStake {
     pub location: u16,
     pub amount: u256,
     pub neighbors_info_packed: u128,
+    pub accumulated_taxes_fee: u128,
 }
 
 

--- a/contracts/src/store.cairo
+++ b/contracts/src/store.cairo
@@ -171,6 +171,11 @@ impl StoreImpl of StoreTrait {
     }
 
     #[inline(always)]
+    fn get_claim_fee_threshold(self: Store) -> u128 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("claim_fee_threshold"))
+    }
+
+    #[inline(always)]
     fn get_buy_fee(self: Store) -> u128 {
         self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("buy_fee"))
     }

--- a/contracts/src/store.cairo
+++ b/contracts/src/store.cairo
@@ -5,6 +5,7 @@ use ponzi_land::models::land::{Land, PoolKey, LandStake};
 use ponzi_land::models::auction::Auction;
 use ponzi_land::models::config::Config;
 use starknet::contract_address::ContractAddressZeroable;
+use starknet::ContractAddress;
 
 #[derive(Copy, Drop)]
 struct Store {
@@ -162,5 +163,27 @@ impl StoreImpl of StoreTrait {
     #[inline(always)]
     fn get_max_circles(self: Store) -> u16 {
         self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("max_circles"))
+    }
+
+    #[inline(always)]
+    fn get_claim_fee(self: Store) -> u128 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("claim_fee"))
+    }
+
+    #[inline(always)]
+    fn get_buy_fee(self: Store) -> u128 {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("buy_fee"))
+    }
+
+    #[inline(always)]
+    fn get_our_contract_for_fee(self: Store) -> ContractAddress {
+        self.world.read_member(Model::<Config>::ptr_from_keys(1), selector!("our_contract_for_fee"))
+    }
+
+    #[inline(always)]
+    fn get_our_contract_for_auction(self: Store) -> ContractAddress {
+        self
+            .world
+            .read_member(Model::<Config>::ptr_from_keys(1), selector!("our_contract_for_auction"))
     }
 }

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -274,6 +274,7 @@ pub mod actions {
             let neighbors = get_land_neighbors(store, land.location);
             let our_contract_for_fee = store.get_our_contract_for_fee();
             let claim_fee = store.get_claim_fee();
+            let claim_fee_threshold = store.get_claim_fee_threshold();
             self
                 .internal_claim(
                     store,
@@ -283,6 +284,7 @@ pub mod actions {
                     our_contract_address,
                     false,
                     claim_fee,
+                    claim_fee_threshold,
                     our_contract_for_fee,
                 );
 
@@ -298,6 +300,7 @@ pub mod actions {
                         our_contract_address,
                         true,
                         claim_fee,
+                        claim_fee_threshold,
                         our_contract_for_fee,
                     );
             };
@@ -353,6 +356,7 @@ pub mod actions {
             let neighbors = get_land_neighbors(store, land.location);
 
             let claim_fee = store.get_claim_fee();
+            let claim_fee_threshold = store.get_claim_fee_threshold();
             let our_contract_for_fee = store.get_our_contract_for_fee();
             self
                 .internal_claim(
@@ -363,6 +367,7 @@ pub mod actions {
                     our_contract_address,
                     false,
                     claim_fee,
+                    claim_fee_threshold,
                     our_contract_for_fee,
                 );
         }
@@ -375,6 +380,7 @@ pub mod actions {
             let current_time = get_block_timestamp();
             let our_contract_address = get_contract_address();
             let claim_fee = store.get_claim_fee();
+            let claim_fee_threshold = store.get_claim_fee_threshold();
             let our_contract_for_fee = store.get_our_contract_for_fee();
 
             for land_location in land_locations {
@@ -394,6 +400,7 @@ pub mod actions {
                             our_contract_address,
                             false,
                             claim_fee,
+                            claim_fee_threshold,
                             our_contract_for_fee,
                         );
                 }
@@ -862,6 +869,7 @@ pub mod actions {
             our_contract_address: ContractAddress,
             from_buy: bool,
             claim_fee: u128,
+            claim_fee_threshold: u128,
             our_contract_for_fee: ContractAddress,
         ) {
             if neighbors.len() != 0 {
@@ -878,6 +886,7 @@ pub mod actions {
                             current_time,
                             our_contract_address,
                             claim_fee,
+                            claim_fee_threshold,
                             our_contract_for_fee,
                         );
 

--- a/contracts/src/systems/config.cairo
+++ b/contracts/src/systems/config.cairo
@@ -35,6 +35,7 @@ trait IConfigSystem<T> {
         buy_fee: u128,
         our_contract_for_fee: ContractAddress,
         our_contract_for_auction: ContractAddress,
+        claim_fee_threshold: u128,
     );
 
     /// @notice Sets the grid width, which determines the size of the land map.
@@ -164,6 +165,10 @@ trait IConfigSystem<T> {
     /// @param value The new our contract for auction.
     fn set_our_contract_for_auction(ref self: T, value: ContractAddress);
 
+    /// @notice Sets the claim fee threshold.
+    /// @param value The new claim fee threshold.
+    fn set_claim_fee_threshold(ref self: T, value: u128);
+
     // Getters
     fn get_grid_width(self: @T) -> u16;
     fn get_tax_rate(self: @T) -> u16;
@@ -186,6 +191,7 @@ trait IConfigSystem<T> {
     fn get_max_circles(self: @T) -> u16;
     fn get_claim_fee(self: @T) -> u128;
     fn get_buy_fee(self: @T) -> u128;
+    fn get_claim_fee_threshold(self: @T) -> u128;
 }
 
 #[dojo::contract]
@@ -234,6 +240,7 @@ mod config {
         buy_fee: u128,
         our_contract_for_fee: ContractAddress,
         our_contract_for_auction: ContractAddress,
+        claim_fee_threshold: u128,
     ) {
         let mut world = self.world_default();
         let init_config: Config = ConfigTrait::new(
@@ -260,6 +267,7 @@ mod config {
             buy_fee,
             our_contract_for_fee,
             our_contract_for_auction,
+            claim_fee_threshold,
         );
         world.write_model(@init_config);
     }
@@ -292,6 +300,7 @@ mod config {
             buy_fee: u128,
             our_contract_for_fee: ContractAddress,
             our_contract_for_auction: ContractAddress,
+            claim_fee_threshold: u128,
         ) {
             let mut world = self.world_default();
             assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
@@ -319,6 +328,7 @@ mod config {
                 buy_fee,
                 our_contract_for_fee,
                 our_contract_for_auction,
+                claim_fee_threshold,
             );
             world.write_model(@new_config);
         }
@@ -555,6 +565,19 @@ mod config {
                 );
         }
 
+        fn set_claim_fee_threshold(ref self: ContractState, value: u128) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("claim_fee_threshold"), value,
+                );
+            world
+                .emit_event(
+                    @ConfigUpdated { field: 'claim_fee_threshold', new_value: value.into() },
+                );
+        }
+
         // Getters implementation
         fn get_grid_width(self: @ContractState) -> u16 {
             let world = self.world_default();
@@ -665,6 +688,11 @@ mod config {
         fn get_buy_fee(self: @ContractState) -> u128 {
             let world = self.world_default();
             world.read_member(Model::<Config>::ptr_from_keys(1), selector!("buy_fee"))
+        }
+
+        fn get_claim_fee_threshold(self: @ContractState) -> u128 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("claim_fee_threshold"))
         }
     }
     #[generate_trait]

--- a/contracts/src/systems/config.cairo
+++ b/contracts/src/systems/config.cairo
@@ -2,6 +2,9 @@
 // Allows the contract owner to update global economic and gameplay parameters.
 // Each setter updates a specific field in the Config model, which is then used by core game logic
 // in systems such as actions, taxes, and staking.
+
+use starknet::ContractAddress;
+
 #[starknet::interface]
 trait IConfigSystem<T> {
     /// @notice Set the full config.
@@ -28,6 +31,10 @@ trait IConfigSystem<T> {
         drop_rate: u8,
         rate_denominator: u8,
         max_circles: u16,
+        claim_fee: u128,
+        buy_fee: u128,
+        our_contract_for_fee: ContractAddress,
+        our_contract_for_auction: ContractAddress,
     );
 
     /// @notice Sets the grid width, which determines the size of the land map.
@@ -139,6 +146,24 @@ trait IConfigSystem<T> {
     /// Used to limit the number of lands that can be created in the game.
     fn set_max_circles(ref self: T, value: u16);
 
+    /// @notice Sets the claim fee.
+    /// @param value The new claim fee.
+    /// Used to calculate the fee for claiming a land. // 0.05% = 0.0005 * SCALE_FACTOR = 500
+    fn set_claim_fee(ref self: T, value: u128);
+
+    /// @notice Sets the buy fee.
+    /// @param value The new buy fee.
+    /// Used to calculate the fee for buying a land. // 0.01% = 0.0001 * SCALE_FACTOR = 100
+    fn set_buy_fee(ref self: T, value: u128);
+
+    /// @notice Sets the our contract for fee.
+    /// @param value The new our contract for fee.
+    fn set_our_contract_for_fee(ref self: T, value: ContractAddress);
+
+    /// @notice Sets the our contract for auction.
+    /// @param value The new our contract for auction.
+    fn set_our_contract_for_auction(ref self: T, value: ContractAddress);
+
     // Getters
     fn get_grid_width(self: @T) -> u16;
     fn get_tax_rate(self: @T) -> u16;
@@ -159,6 +184,8 @@ trait IConfigSystem<T> {
     fn get_drop_rate(self: @T) -> u8;
     fn get_rate_denominator(self: @T) -> u8;
     fn get_max_circles(self: @T) -> u16;
+    fn get_claim_fee(self: @T) -> u128;
+    fn get_buy_fee(self: @T) -> u128;
 }
 
 #[dojo::contract]
@@ -203,6 +230,10 @@ mod config {
         drop_rate: u8,
         rate_denominator: u8,
         max_circles: u16,
+        claim_fee: u128,
+        buy_fee: u128,
+        our_contract_for_fee: ContractAddress,
+        our_contract_for_auction: ContractAddress,
     ) {
         let mut world = self.world_default();
         let init_config: Config = ConfigTrait::new(
@@ -225,6 +256,10 @@ mod config {
             drop_rate,
             rate_denominator,
             max_circles,
+            claim_fee,
+            buy_fee,
+            our_contract_for_fee,
+            our_contract_for_auction,
         );
         world.write_model(@init_config);
     }
@@ -253,6 +288,10 @@ mod config {
             drop_rate: u8,
             rate_denominator: u8,
             max_circles: u16,
+            claim_fee: u128,
+            buy_fee: u128,
+            our_contract_for_fee: ContractAddress,
+            our_contract_for_auction: ContractAddress,
         ) {
             let mut world = self.world_default();
             assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
@@ -276,6 +315,10 @@ mod config {
                 drop_rate,
                 rate_denominator,
                 max_circles,
+                claim_fee,
+                buy_fee,
+                our_contract_for_fee,
+                our_contract_for_auction,
             );
             world.write_model(@new_config);
         }
@@ -472,6 +515,46 @@ mod config {
             world.emit_event(@ConfigUpdated { field: 'max_circles', new_value: value.into() });
         }
 
+        fn set_claim_fee(ref self: ContractState, value: u128) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world.write_member(Model::<Config>::ptr_from_keys(1), selector!("claim_fee"), value);
+            world.emit_event(@ConfigUpdated { field: 'claim_fee', new_value: value.into() });
+        }
+
+        fn set_buy_fee(ref self: ContractState, value: u128) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world.write_member(Model::<Config>::ptr_from_keys(1), selector!("buy_fee"), value);
+            world.emit_event(@ConfigUpdated { field: 'buy_fee', new_value: value.into() });
+        }
+
+        fn set_our_contract_for_fee(ref self: ContractState, value: ContractAddress) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("our_contract_for_fee"), value,
+                );
+            world
+                .emit_event(
+                    @ConfigUpdated { field: 'our_contract_for_fee', new_value: value.into() },
+                );
+        }
+
+        fn set_our_contract_for_auction(ref self: ContractState, value: ContractAddress) {
+            let mut world = self.world_default();
+            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            world
+                .write_member(
+                    Model::<Config>::ptr_from_keys(1), selector!("our_contract_for_auction"), value,
+                );
+            world
+                .emit_event(
+                    @ConfigUpdated { field: 'our_contract_for_auction', new_value: value.into() },
+                );
+        }
+
         // Getters implementation
         fn get_grid_width(self: @ContractState) -> u16 {
             let world = self.world_default();
@@ -572,6 +655,16 @@ mod config {
         fn get_max_circles(self: @ContractState) -> u16 {
             let world = self.world_default();
             world.read_member(Model::<Config>::ptr_from_keys(1), selector!("max_circles"))
+        }
+
+        fn get_claim_fee(self: @ContractState) -> u128 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("claim_fee"))
+        }
+
+        fn get_buy_fee(self: @ContractState) -> u128 {
+            let world = self.world_default();
+            world.read_member(Model::<Config>::ptr_from_keys(1), selector!("buy_fee"))
         }
     }
     #[generate_trait]

--- a/contracts/src/tests/actions.cairo
+++ b/contracts/src/tests/actions.cairo
@@ -560,11 +560,21 @@ fn test_claim_and_add_taxes() {
         erc20_neighbor_1,
     );
     let neighbor_land_before_claim = store.land_stake(next_auction_location.unwrap());
+    let accumulated_fee_before_claim = neighbor_land_before_claim.accumulated_taxes_fee;
     let our_contract_for_fee_before_claim = erc20_neighbor_1
         .balanceOf(OUR_CONTRACT_FOR_FEE.try_into().unwrap());
     // Simulate time difference to generate taxes
     let our_contract_for_fee = OUR_CONTRACT_FOR_FEE.try_into().unwrap();
     set_block_timestamp(20000);
+    set_contract_address(RECIPIENT());
+    actions_system.claim(CENTER_LOCATION);
+    let accumulated_fee_after_claim = store
+        .land_stake(next_auction_location.unwrap())
+        .accumulated_taxes_fee;
+
+    assert(accumulated_fee_after_claim > accumulated_fee_before_claim, 'fail in accumalated fees');
+
+    set_block_timestamp(40000);
     set_contract_address(RECIPIENT());
     actions_system.claim(CENTER_LOCATION);
     let our_contract_for_fee_after_claim = erc20_neighbor_1.balanceOf(our_contract_for_fee);

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -28,7 +28,7 @@ mod setup {
         MAX_AUCTIONS_FROM_BID, DECAY_RATE, FLOOR_PRICE, LIQUIDITY_SAFETY_MULTIPLIER,
         MIN_AUCTION_PRICE, MIN_AUCTION_PRICE_MULTIPLIER, CENTER_LOCATION, AUCTION_DURATION,
         SCALING_FACTOR, LINEAR_DECAY_TIME, DROP_RATE, RATE_DENOMINATOR, MAX_CIRCLES, CLAIM_FEE,
-        BUY_FEE, OUR_CONTRACT_FOR_FEE, OUR_CONTRACT_SEPOLIA_ADDRESS,
+        BUY_FEE, OUR_CONTRACT_FOR_FEE, OUR_CONTRACT_SEPOLIA_ADDRESS, CLAIM_FEE_THRESHOLD,
     };
     use ponzi_land::systems::actions::{actions, IActionsDispatcher, IActionsDispatcherTrait};
     use ponzi_land::components::taxes::{TaxesComponent};
@@ -159,6 +159,7 @@ mod setup {
                             LINEAR_DECAY_TIME.into(), DROP_RATE.into(), RATE_DENOMINATOR.into(),
                             MAX_CIRCLES.into(), CLAIM_FEE.into(), BUY_FEE.into(),
                             OUR_CONTRACT_FOR_FEE, OUR_CONTRACT_SEPOLIA_ADDRESS,
+                            CLAIM_FEE_THRESHOLD.into(),
                         ]
                             .span(),
                     ),

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -27,7 +27,8 @@ mod setup {
         GRID_WIDTH, TAX_RATE, BASE_TIME, PRICE_DECREASE_RATE, TIME_SPEED, MAX_AUCTIONS,
         MAX_AUCTIONS_FROM_BID, DECAY_RATE, FLOOR_PRICE, LIQUIDITY_SAFETY_MULTIPLIER,
         MIN_AUCTION_PRICE, MIN_AUCTION_PRICE_MULTIPLIER, CENTER_LOCATION, AUCTION_DURATION,
-        SCALING_FACTOR, LINEAR_DECAY_TIME, DROP_RATE, RATE_DENOMINATOR, MAX_CIRCLES,
+        SCALING_FACTOR, LINEAR_DECAY_TIME, DROP_RATE, RATE_DENOMINATOR, MAX_CIRCLES, CLAIM_FEE,
+        BUY_FEE, OUR_CONTRACT_FOR_FEE, OUR_CONTRACT_SEPOLIA_ADDRESS,
     };
     use ponzi_land::systems::actions::{actions, IActionsDispatcher, IActionsDispatcherTrait};
     use ponzi_land::components::taxes::{TaxesComponent};
@@ -42,6 +43,7 @@ mod setup {
     fn RECIPIENT() -> ContractAddress {
         contract_address_const::<'RECIPIENT'>()
     }
+
 
     fn create_setup() -> (
         WorldStorage,
@@ -155,7 +157,8 @@ mod setup {
                             MIN_AUCTION_PRICE_MULTIPLIER.into(), CENTER_LOCATION.into(),
                             AUCTION_DURATION.into(), SCALING_FACTOR.into(),
                             LINEAR_DECAY_TIME.into(), DROP_RATE.into(), RATE_DENOMINATOR.into(),
-                            MAX_CIRCLES.into(),
+                            MAX_CIRCLES.into(), CLAIM_FEE.into(), BUY_FEE.into(),
+                            OUR_CONTRACT_FOR_FEE, OUR_CONTRACT_SEPOLIA_ADDRESS,
                         ]
                             .span(),
                     ),


### PR DESCRIPTION
### TL;DR

Implement fee system for land transactions and update Dojo version to 1.6.0-alpha.2.

### What changed?
- Added fee system for land transactions:
  - Implemented `proccess_payment_with_fee_for_buy` and `proccess_payment_with_fee_for_claim` in the Payable component
  - Added fee-related constants: `SCALE_FACTOR_FOR_FEE`, `CLAIM_FEE`, `BUY_FEE`, and `OUR_CONTRACT_FOR_FEE`
  - Updated the Config model to include fee-related fields
  - Modified the claim and buy actions to incorporate fee processing
- Added new getters in the Store for fee-related configuration
- Updated the Config system to support setting and retrieving fee parameters
- Modified tests to verify fee payments


### Why make this change?

This change introduces a fee system to generate revenue from land transactions in the game. By taking a small percentage of each transaction (buy and claim), the platform can sustain itself while maintaining a fair economic model for players. The fee system is configurable, allowing for adjustments based on economic conditions. Additionally, updating to the latest Dojo version ensures compatibility with the latest features and improvements.