### PR TITLE
add reentrancy guard

### DIFF
--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -51,6 +51,11 @@ version = "1.0.0"
 source = "git+https://github.com/OpenZeppelin/cairo-contracts?tag=v1.0.0#755ce1adbf8d89ed23fbb8daa328fcbeab7c6424"
 
 [[package]]
+name = "openzeppelin_security"
+version = "1.0.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?tag=v1.0.0#755ce1adbf8d89ed23fbb8daa328fcbeab7c6424"
+
+[[package]]
 name = "openzeppelin_token"
 version = "1.0.0"
 source = "git+https://github.com/OpenZeppelin/cairo-contracts?tag=v1.0.0#755ce1adbf8d89ed23fbb8daa328fcbeab7c6424"
@@ -73,5 +78,6 @@ dependencies = [
  "dojo",
  "dojo_cairo_test",
  "ekubo",
+ "openzeppelin_security",
  "openzeppelin_token",
 ]

--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -15,6 +15,7 @@ move = "sozo execute ponzi_land-actions move -c 1 --wait" # scarb run move
 [dependencies]
 dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.6.0-alpha.2" }
 openzeppelin_token = { git = "https://github.com/OpenZeppelin/cairo-contracts", tag = "v1.0.0" }
+openzeppelin_security = { git = "https://github.com/OpenZeppelin/cairo-contracts", tag = "v1.0.0" }
 ekubo = { git = "https://github.com/EkuboProtocol/abis", rev = "edb6de8c9baf515f1053bbab3d86825d54a63bc3" }
 
 [profile.sepolia]


### PR DESCRIPTION
### TL;DR

Added reentrancy protection to the smart contract to prevent potential exploits.

### What changed?

- Added the OpenZeppelin Security dependency to the project
- Integrated the `ReentrancyGuardComponent` from OpenZeppelin into the contract
- Applied reentrancy protection to critical functions:
  - `buy`
  - `claim`
  - `claim_all`
  - `bid`
  - `increase_stake`
  - `reimburse_stakes`
- Each protected function now calls `start()` at the beginning and `end()` at the completion to prevent reentrant calls


### Why make this change?

Reentrancy attacks are a common vulnerability in smart contracts where an attacker can recursively call back into a contract before the first invocation is complete. This change prevents such attacks by implementing a mutex-like guard that blocks reentrant calls to sensitive functions that handle token transfers or state changes, enhancing the security of the contract.