### PR TITLE
remove unnecessary check

### DIFF
--- a/contracts/src/helpers/coord.cairo
+++ b/contracts/src/helpers/coord.cairo
@@ -18,11 +18,6 @@ fn index_to_position(index: u16) -> (u8, u8) {
     (row, col)
 }
 
-fn is_valid_position(index: u16) -> bool {
-    let (row, col) = index_to_position(index);
-    row <= MAX_GRID_SIZE && col <= MAX_GRID_SIZE
-}
-
 
 fn left(index: u16) -> Option<u16> {
     let (row, col) = index_to_position(index);
@@ -161,11 +156,7 @@ fn max_neighbors(index: u16) -> u8 {
 
 #[cfg(test)]
 mod coord_test {
-    use super::{
-        position_to_index, index_to_position, left, right, up, down, is_valid_position,
-        max_neighbors,
-    };
-
+    use super::{position_to_index, index_to_position, left, right, up, down, max_neighbors};
     #[test]
     fn test_position_to_index() {
         assert_eq!(position_to_index(0, 0), 0);
@@ -210,14 +201,6 @@ mod coord_test {
         assert_eq!(down(256), Option::Some(512));
         assert_eq!(down(257), Option::Some(513));
         assert_eq!(down(64781), Option::Some(65037));
-    }
-
-    #[test]
-    fn test_is_valid_position() {
-        assert(is_valid_position(position_to_index(0, 10)), 'has to be true');
-        assert(is_valid_position(position_to_index(200, 200)), 'has to be true');
-        assert(is_valid_position(position_to_index(255, 255)), 'has to be true');
-        assert(is_valid_position(position_to_index(0, 0)), 'has to be true');
     }
 
     #[test]

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -101,7 +101,7 @@ pub mod actions {
     use ponzi_land::utils::level_up::{calculate_new_level};
     use ponzi_land::utils::stake::{calculate_refund_amount};
 
-    use ponzi_land::helpers::coord::{is_valid_position, get_all_neighbors};
+    use ponzi_land::helpers::coord::{get_all_neighbors};
     use ponzi_land::helpers::taxes::{get_taxes_per_neighbor, get_tax_rate_per_neighbor};
     use ponzi_land::helpers::circle_expansion::{
         get_circle_land_position, get_random_index, lands_per_section, is_section_completed,
@@ -271,7 +271,6 @@ pub mod actions {
             );
 
             let mut store = StoreTrait::new(world);
-            assert(is_valid_position(land_location), 'Land location not valid');
             let land = store.land(land_location);
 
             assert(caller != land.owner, 'you already own this land');
@@ -362,7 +361,6 @@ pub mod actions {
             let our_contract_address = get_contract_address();
             assert(world.auth_dispatcher().can_take_action(caller), 'action not permitted');
             let mut store = StoreTrait::new(world);
-            assert(is_valid_position(land_location), 'Land location not valid');
 
             let land = store.land(land_location);
             assert(land.owner == caller, 'not the owner');
@@ -400,7 +398,6 @@ pub mod actions {
 
             for land_location in land_locations {
                 if !self.active_auction_queue.read(land_location) {
-                    assert(is_valid_position(land_location), 'Land location not valid');
                     let land = store.land(land_location);
                     if land.owner != caller {
                         continue;
@@ -441,7 +438,6 @@ pub mod actions {
             let mut store = StoreTrait::new(world);
             let mut land = store.land(land_location);
 
-            assert(is_valid_position(land_location), 'Land location not valid');
             assert(land.owner == ContractAddressZeroable::zero(), 'must be without owner');
             assert(sell_price > 0, 'sell_price > 0');
             assert(amount_to_stake > 0, 'amount_to_stake > 0');
@@ -485,7 +481,6 @@ pub mod actions {
             assert(contract_owner == caller, 'action not permitted');
 
             let mut store = StoreTrait::new(world);
-            assert(is_valid_position(land_location), 'Land location not valid');
             let mut land = store.land(land_location);
             let mut land_stake = store.land_stake(land_location);
             assert(land.owner == ContractAddressZeroable::zero(), 'land must be without owner');
@@ -517,7 +512,6 @@ pub mod actions {
             assert(world.auth_dispatcher().can_take_action(caller), 'action not permitted');
 
             let mut store = StoreTrait::new(world);
-            assert(is_valid_position(land_location), 'Land location not valid');
 
             let mut land = store.land(land_location);
 
@@ -536,7 +530,6 @@ pub mod actions {
             assert(world.auth_dispatcher().can_take_action(caller), 'action not permitted');
 
             let mut store = StoreTrait::new(world);
-            assert(is_valid_position(land_location), 'Land location not valid');
 
             let land = store.land(land_location);
 
@@ -558,7 +551,6 @@ pub mod actions {
             assert(world.auth_dispatcher().can_take_action(caller), 'action not permitted');
 
             let mut store = StoreTrait::new(world);
-            assert(is_valid_position(land_location), 'Land location not valid');
             let mut land = store.land(land_location);
 
             assert(land.owner == caller, 'not the owner');
@@ -603,7 +595,6 @@ pub mod actions {
         fn get_land(self: @ContractState, land_location: u16) -> (Land, LandStake) {
             let mut world = self.world_default();
             let store = StoreTrait::new(world);
-            assert(is_valid_position(land_location), 'Land location not valid');
             let land = store.land(land_location);
             let land_stake = store.land_stake(land_location);
             (land, land_stake)
@@ -613,7 +604,6 @@ pub mod actions {
         fn get_current_auction_price(self: @ContractState, land_location: u16) -> u256 {
             let mut world = self.world_default();
             let store = StoreTrait::new(world);
-            assert(is_valid_position(land_location), 'Land location not valid');
             let auction = store.auction(land_location);
 
             if auction.is_finished {
@@ -625,7 +615,6 @@ pub mod actions {
         fn get_next_claim_info(self: @ContractState, land_location: u16) -> Array<ClaimInfo> {
             let mut world = self.world_default();
             let store = StoreTrait::new(world);
-            assert(is_valid_position(land_location), 'Land location not valid');
             let land = store.land(land_location);
             let current_time = get_block_timestamp();
             let neighbors = get_land_neighbors(store, land.location);
@@ -696,7 +685,6 @@ pub mod actions {
         fn get_neighbors_yield(self: @ContractState, land_location: u16) -> LandYieldInfo {
             let mut world = self.world_default();
             let store = StoreTrait::new(world);
-            assert(is_valid_position(land_location), 'Land location not valid');
             let land = store.land(land_location);
             let neighbors = get_land_neighbors(store, land.location);
             let neighbors_count = neighbors.len();
@@ -737,7 +725,6 @@ pub mod actions {
         fn get_auction(self: @ContractState, land_location: u16) -> Auction {
             let mut world = self.world_default();
             let store = StoreTrait::new(world);
-            assert(is_valid_position(land_location), 'Land location not valid');
             store.auction(land_location)
         }
 
@@ -820,7 +807,6 @@ pub mod actions {
             decay_rate: u16,
             is_from_nuke: bool,
         ) {
-            assert(is_valid_position(land_location), 'Land location not valid');
             assert(start_price > 0, 'start_price > 0');
             assert(floor_price > 0, 'floor_price > 0');
             //we don't want generate an error if the auction is full


### PR DESCRIPTION
# Remove Unnecessary Position Validation

This PR removes the redundant `is_valid_position` function and its associated validation checks throughout the codebase. The function was unnecessary since the coordinate system already ensures valid positions through its implementation, and removing these checks simplifies the code without affecting functionality.