### PR TITLE
hotfix/fix u64 overflow

### DIFF
--- a/contracts/src/utils/math.cairo
+++ b/contracts/src/utils/math.cairo
@@ -1,8 +1,20 @@
+use core::num::traits::Bounded;
+
 #[inline(always)]
 pub fn u64_saturating_sub(a: u64, b: u64) -> u64 {
     if a > b {
         a - b
     } else {
         0
+    }
+}
+
+#[inline(always)]
+pub fn u64_saturating_add(a: u64, b: u64) -> u64 {
+    let max_u64 = Bounded::<u64>::MAX;
+    if a > max_u64 - b {
+        max_u64
+    } else {
+        a + b
     }
 }


### PR DESCRIPTION
### TL;DR

Fix nuke time calculation logic to handle edge cases properly.

### What changed?

- Added a new `u64_saturating_add` utility function to prevent overflow when adding u64 values
- Modified the `calculate_nuke_time` function to:
  - Return 0 when tax rate or time speed is 0 (instead of returning max u64)
  - Initialize `min_remaining_time` with the calculated remaining time units
  - Return the current timestamp when `min_remaining_time` is 0
  - Use `u64_saturating_add` to safely add the current time and remaining time


### Why make this change?

The previous implementation had issues with edge cases in nuke time calculation:
1. It would return a far-future timestamp when tax rate or time speed was 0, which is incorrect
2. It didn't properly handle the case when remaining time was 0
3. It was vulnerable to potential overflow when adding timestamps

This change ensures more accurate nuke time calculations and better handling of edge cases, improving the reliability of the tax system.