### PR TITLE
add owner validation with RBAC

### DIFF
--- a/contracts/dojo_mainnet-test.toml
+++ b/contracts/dojo_mainnet-test.toml
@@ -39,7 +39,6 @@ ipfs_config.password = "12290b883db9138a8ae3363b6739d220"
 ]
 
 "ponzi_land-auth" = [
-    "0x0515b1ef6e23a6ce07f4ca8849c11735c86c87da1249a504ead63af3aa447eef", # Owner address
     "0x001c012e0e8408af283483480f18c0f7a313e76012a06b158913d71cc304ba3b", # Verifier
 ]
 

--- a/contracts/dojo_mainnet.toml
+++ b/contracts/dojo_mainnet.toml
@@ -39,7 +39,6 @@ ipfs_config.password = "12290b883db9138a8ae3363b6739d220"
 ]
 
 "ponzi_land-auth" = [
-    "0x021fBAE9F9343873ab25eC14d287A1170b676C73c97906790ef91F5428dBdbad", # Owner address
     "0x001c012e0e8408af283483480f18c0f7a313e76012a06b158913d71cc304ba3b", # Verifier
 ]
 

--- a/contracts/dojo_sepolia.toml
+++ b/contracts/dojo_sepolia.toml
@@ -39,7 +39,6 @@ ipfs_config.password = "12290b883db9138a8ae3363b6739d220"
 ]
 
 "ponzi_land-auth" = [
-    "0x01c9dF838eaa6790C1B7AE998c18126D236ec2B4bD86c00636FcA3ce137bD1c9", # Owner
     "0x001c012e0e8408af283483480f18c0f7a313e76012a06b158913d71cc304ba3b", # Verifier
 ]
 

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -449,8 +449,7 @@ pub mod actions {
         fn recreate_auction(ref self: ContractState, land_location: u16) {
             let caller = get_caller_address();
             let mut world = self.world_default();
-            let contract_owner = world.auth_dispatcher().get_owner();
-            assert(contract_owner == caller, 'action not permitted');
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'action not permitted');
 
             let mut store = StoreTrait::new(world);
             let mut land = store.land(land_location);
@@ -535,7 +534,8 @@ pub mod actions {
         fn reimburse_stakes(ref self: ContractState) {
             self.reentrancy_guard.start();
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
 
             let mut store = StoreTrait::new(world);
             let mut active_lands: Array<Land> = ArrayTrait::new();

--- a/contracts/src/systems/config.cairo
+++ b/contracts/src/systems/config.cairo
@@ -306,7 +306,8 @@ mod config {
             main_currency: ContractAddress,
         ) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             let new_config: Config = ConfigTrait::new(
                 tax_rate,
                 base_time,
@@ -337,21 +338,24 @@ mod config {
 
         fn set_tax_rate(ref self: ContractState, value: u16) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world.write_member(Model::<Config>::ptr_from_keys(1), selector!("tax_rate"), value);
             world.emit_event(@ConfigUpdated { field: 'tax_rate', new_value: value.into() });
         }
 
         fn set_base_time(ref self: ContractState, value: u16) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world.write_member(Model::<Config>::ptr_from_keys(1), selector!("base_time"), value);
             world.emit_event(@ConfigUpdated { field: 'base_time', new_value: value.into() });
         }
 
         fn set_price_decrease_rate(ref self: ContractState, value: u16) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1), selector!("price_decrease_rate"), value,
@@ -364,21 +368,24 @@ mod config {
 
         fn set_time_speed(ref self: ContractState, value: u32) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world.write_member(Model::<Config>::ptr_from_keys(1), selector!("time_speed"), value);
             world.emit_event(@ConfigUpdated { field: 'time_speed', new_value: value.into() });
         }
 
         fn set_max_auctions(ref self: ContractState, value: u8) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world.write_member(Model::<Config>::ptr_from_keys(1), selector!("max_auctions"), value);
             world.emit_event(@ConfigUpdated { field: 'max_auctions', new_value: value.into() });
         }
 
         fn set_max_auctions_from_bid(ref self: ContractState, value: u8) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1), selector!("max_auctions_from_bid"), value,
@@ -391,14 +398,16 @@ mod config {
 
         fn set_decay_rate(ref self: ContractState, value: u16) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world.write_member(Model::<Config>::ptr_from_keys(1), selector!("decay_rate"), value);
             world.emit_event(@ConfigUpdated { field: 'decay_rate', new_value: value.into() });
         }
 
         fn set_floor_price(ref self: ContractState, value: u256) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world.write_member(Model::<Config>::ptr_from_keys(1), selector!("floor_price"), value);
             world
                 .emit_event(
@@ -408,7 +417,8 @@ mod config {
 
         fn set_liquidity_safety_multiplier(ref self: ContractState, value: u8) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1),
@@ -425,7 +435,8 @@ mod config {
 
         fn set_min_auction_price(ref self: ContractState, value: u256) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1), selector!("min_auction_price"), value,
@@ -440,7 +451,8 @@ mod config {
 
         fn set_min_auction_price_multiplier(ref self: ContractState, value: u8) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1),
@@ -458,7 +470,8 @@ mod config {
 
         fn set_auction_duration(ref self: ContractState, value: u32) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1), selector!("auction_duration"), value,
@@ -468,7 +481,8 @@ mod config {
 
         fn set_scaling_factor(ref self: ContractState, value: u8) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1), selector!("scaling_factor"), value,
@@ -478,7 +492,8 @@ mod config {
 
         fn set_linear_decay_time(ref self: ContractState, value: u16) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1), selector!("linear_decay_time"), value,
@@ -489,14 +504,16 @@ mod config {
 
         fn set_drop_rate(ref self: ContractState, value: u8) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world.write_member(Model::<Config>::ptr_from_keys(1), selector!("drop_rate"), value);
             world.emit_event(@ConfigUpdated { field: 'drop_rate', new_value: value.into() });
         }
 
         fn set_rate_denominator(ref self: ContractState, value: u8) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1), selector!("rate_denominator"), value,
@@ -506,28 +523,32 @@ mod config {
 
         fn set_max_circles(ref self: ContractState, value: u16) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world.write_member(Model::<Config>::ptr_from_keys(1), selector!("max_circles"), value);
             world.emit_event(@ConfigUpdated { field: 'max_circles', new_value: value.into() });
         }
 
         fn set_claim_fee(ref self: ContractState, value: u128) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world.write_member(Model::<Config>::ptr_from_keys(1), selector!("claim_fee"), value);
             world.emit_event(@ConfigUpdated { field: 'claim_fee', new_value: value.into() });
         }
 
         fn set_buy_fee(ref self: ContractState, value: u128) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world.write_member(Model::<Config>::ptr_from_keys(1), selector!("buy_fee"), value);
             world.emit_event(@ConfigUpdated { field: 'buy_fee', new_value: value.into() });
         }
 
         fn set_our_contract_for_fee(ref self: ContractState, value: ContractAddress) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1), selector!("our_contract_for_fee"), value,
@@ -540,7 +561,8 @@ mod config {
 
         fn set_our_contract_for_auction(ref self: ContractState, value: ContractAddress) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1), selector!("our_contract_for_auction"), value,
@@ -553,7 +575,8 @@ mod config {
 
         fn set_claim_fee_threshold(ref self: ContractState, value: u128) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(
                     Model::<Config>::ptr_from_keys(1), selector!("claim_fee_threshold"), value,
@@ -566,7 +589,8 @@ mod config {
 
         fn set_main_currency(ref self: ContractState, value: ContractAddress) {
             let mut world = self.world_default();
-            assert(world.auth_dispatcher().get_owner() == get_caller_address(), 'not the owner');
+            let caller = get_caller_address();
+            assert(world.auth_dispatcher().is_owner_auth(caller), 'not the owner');
             world
                 .write_member(Model::<Config>::ptr_from_keys(1), selector!("main_currency"), value);
             world.emit_event(@ConfigUpdated { field: 'main_currency', new_value: value.into() });

--- a/contracts/src/tests/actions.cairo
+++ b/contracts/src/tests/actions.cairo
@@ -180,6 +180,12 @@ fn authorize_token(dispatcher: ITokenRegistryDispatcher, token_address: Contract
 }
 
 fn authorize_all_addresses(auth_dispatcher: IAuthDispatcher) {
+    // We need to temporarily mock ourselves as the world owner to call set_verifier
+    // Similar pattern to authorize_token function
+    let prev_address = starknet::get_contract_address();
+
+    set_contract_address(0x0.try_into().unwrap());
+
     //PRIVATE KEY => 0x1234567890987654321
     let public_key: felt252 =
         0x020c29f1c98f3320d56f01c13372c923123c35828bce54f2153aa1cfe61c44f2; // From script
@@ -237,6 +243,9 @@ fn authorize_all_addresses(auth_dispatcher: IAuthDispatcher) {
         assert(auth_dispatcher.can_take_action(address), 'Authorization failed');
         i += 1;
     };
+
+    // Restore the original contract address
+    set_contract_address(prev_address);
 }
 
 fn validate_staking_state(
@@ -1317,7 +1326,7 @@ fn test_dynamic_grid() {
     initialize_land(
         actions_system, main_currency, RECIPIENT(), CENTER_LOCATION, 10, 50, main_currency,
     );
-
+    set_contract_address(0x0.try_into().unwrap());
     let initial_max_circles = store.get_max_circles();
     assert(initial_max_circles == MAX_CIRCLES, 'max circles should be default');
 

--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -176,8 +176,7 @@ mod setup {
             .append(
                 ContractDefTrait::new(@"ponzi_land", @"auth")
                     .with_writer_of([dojo::utils::bytearray_hash(@"ponzi_land")].span())
-                    .with_init_calldata([RECIPIENT().into(), // owner
-                    0.into() // verifier
+                    .with_init_calldata([0.into() // verifier
                     ].span()),
             );
 


### PR DESCRIPTION
### TL;DR

Replaced owner address management with World RBAC for improved security and standardization.

### What changed?

- Removed hardcoded owner addresses from all environment configuration files (mainnet, mainnet-test, sepolia)
- Refactored the Auth system to use Dojo World RBAC for owner authorization:
  - Removed `owner` storage variable and `get_owner()` function
  - Added `is_owner_auth()` function that uses World's RBAC system
  - Updated the contract initialization to no longer require an owner parameter
- Updated all owner checks across the codebase to use `is_owner_auth()` instead of comparing with a stored owner address
- Fixed tests to accommodate the new authorization model

### How to test?

1. Run the existing test suite to verify all functionality works with the new authorization model
2. Test owner-only functions to ensure they work correctly with World RBAC
3. Verify that non-owners cannot execute privileged functions

### Why make this change?

This change improves security and standardization by:
1. Leveraging Dojo World's built-in RBAC system instead of maintaining a separate owner address
2. Removing hardcoded owner addresses from configuration files
3. Providing a more flexible permission model that can be managed through World's ownership system
4. Ensuring consistent authorization checks across all owner-restricted functions