### PR TITLE
up max outline and owned lands with instanced buffer attributes to shade/outline unlimited number

### DIFF
--- a/client/src/lib/components/+game-map/three/land-sprite.svelte
+++ b/client/src/lib/components/+game-map/three/land-sprite.svelte
@@ -430,7 +430,7 @@
   });
 
   // Reactive owned lands for shader-based darkening (up to 32 lands)
-  const maxOwnedLands = 32; // Match shader uniform array limit
+  const maxOwnedLands = GRID_SIZE ** 2; // Match shader uniform array limit
   let ownedLandIndices = $state<number[]>([]);
 
   $effect(() => {

--- a/client/src/lib/components/+game-map/three/land-tile-sprite.svelte
+++ b/client/src/lib/components/+game-map/three/land-tile-sprite.svelte
@@ -9,6 +9,7 @@
     setupOutlineShader,
     type OutlineControls,
   } from './utils/sprite-hover-shader';
+  import { setOutlineControls } from './utils/outline-controls.store.svelte';
 
   let {
     landTiles,
@@ -45,6 +46,13 @@
           spritesheet.texture.height,
         ),
       });
+
+      // Register outline controls in the global store
+      // Determine layer type from animation property
+      const layer =
+        animationProperty === 'buildingAnimationName' ? 'building' : 'biome';
+      setOutlineControls(layer, outlineControls, sprite);
+
       shaderSetup = true;
     }
 
@@ -72,12 +80,13 @@
   $effect(() => {
     const hoveredIndex = cursorStore.hoveredTileIndex ?? -1;
     const selectedIndex = cursorStore.selectedTileIndex ?? -1;
-    handleCursorState(outlineControls, hoveredIndex, selectedIndex);
+    handleCursorState(outlineControls, sprite, hoveredIndex, selectedIndex);
   });
 
   $effect(() => {
-    if (outlineControls && ownedLandIndices.length > 0) {
-      outlineControls.setOwnedLands(ownedLandIndices, 0.4, true);
+    if (outlineControls && sprite) {
+      // Always call setOwnedLands to ensure proper clearing when list gets smaller
+      outlineControls.setOwnedLands(sprite, ownedLandIndices, 0.4);
     }
   });
 

--- a/client/src/lib/components/+game-map/three/utils/outline-controls.store.svelte.ts
+++ b/client/src/lib/components/+game-map/three/utils/outline-controls.store.svelte.ts
@@ -1,0 +1,72 @@
+import type { OutlineControls } from './sprite-hover-shader';
+import * as THREE from 'three';
+
+interface OutlineControlsStore {
+  buildingControls: OutlineControls | null;
+  biomeControls: OutlineControls | null;
+  buildingSprite: THREE.InstancedMesh | null;
+  biomeSprite: THREE.InstancedMesh | null;
+}
+
+// Create a reactive store to hold references to outline controls
+const outlineControlsStore = $state<OutlineControlsStore>({
+  buildingControls: null,
+  biomeControls: null,
+  buildingSprite: null,
+  biomeSprite: null,
+});
+
+export function setOutlineControls(
+  layer: 'building' | 'biome',
+  controls: OutlineControls | null,
+  sprite: THREE.InstancedMesh | null = null,
+) {
+  if (layer === 'building') {
+    outlineControlsStore.buildingControls = controls;
+    if (sprite) outlineControlsStore.buildingSprite = sprite;
+  } else {
+    outlineControlsStore.biomeControls = controls;
+    if (sprite) outlineControlsStore.biomeSprite = sprite;
+  }
+}
+
+export function getOutlineControls() {
+  return outlineControlsStore;
+}
+
+// Convenience function to apply outlines to all layers
+export function applyOutlinesToAllLayers(
+  instanceIndices: number[],
+  color: THREE.Color,
+) {
+  const store = getOutlineControls();
+
+  if (store.buildingControls && store.buildingSprite) {
+    store.buildingControls.setCustomOutlines(
+      store.buildingSprite,
+      instanceIndices,
+      color,
+    );
+  }
+
+  if (store.biomeControls && store.biomeSprite) {
+    store.biomeControls.setCustomOutlines(
+      store.biomeSprite,
+      instanceIndices,
+      color,
+    );
+  }
+}
+
+// Convenience function to clear outlines from all layers
+export function clearOutlinesFromAllLayers() {
+  const store = getOutlineControls();
+
+  if (store.buildingControls && store.buildingSprite) {
+    store.buildingControls.clearOutlines(store.buildingSprite);
+  }
+
+  if (store.biomeControls && store.biomeSprite) {
+    store.biomeControls.clearOutlines(store.biomeSprite);
+  }
+}

--- a/client/src/lib/shaders/sprite/vertex_main.glsl
+++ b/client/src/lib/shaders/sprite/vertex_main.glsl
@@ -2,34 +2,12 @@
 // Pass the instance index to the fragment shader
 vInstanceIndex = float(gl_InstanceID); // Use gl_InstanceID for instanced rendering
 
-// Check if this instance is in the outlined instances array
-float isOutlined = 0.0;
-vec3 currentOutlineColor = vec3(1.0, 0.0, 0.0); // Default red
-vec3 currentPulseColor = vec3(1.0, 1.0, 0.0);   // Default yellow
-
-if (hoverState > 0.5) {
-    for (int i = 0; i < 32; i++) {
-        if (i >= numOutlinedInstances) break;
-        if (vInstanceIndex == hoveredInstanceIndices[i]) {
-            isOutlined = 1.0;
-            currentOutlineColor = outlineColors[i];
-            currentPulseColor = pulseColors[i];
-            break;
-        }
-    }
-}
-
-// Check if this instance is owned
-float isOwned = 0.0;
-for (int i = 0; i < 32; i++) {
-    if (i >= numOwnedLands) break;
-    if (vInstanceIndex == ownedLandIndices[i]) {
-        isOwned = 1.0;
-        break;
-    }
-}
+// Use instanced buffer attributes directly
+float isOutlined = outlineState;
+float isOwned = ownedState;
+vec3 currentOutlineColor = outlineColor;
 
 vHover = isOutlined;
 vOutlineColor = currentOutlineColor;
-vPulseColor = currentPulseColor;
+vPulseColor = currentOutlineColor; // Use same color for pulse
 vIsOwned = isOwned;

--- a/client/src/lib/shaders/sprite/vertex_pars.glsl
+++ b/client/src/lib/shaders/sprite/vertex_pars.glsl
@@ -1,16 +1,12 @@
 
-uniform float hoverState;
-uniform float hoveredInstanceIndices[32]; // Support up to 32 outlined instances
-uniform int numOutlinedInstances;
-uniform vec3 outlineColors[32]; // Support up to 32 different outline colors
-uniform vec3 pulseColors[32];   // Support up to 32 different pulse colors
-
-// Owned land uniforms
-uniform float ownedLandIndices[32]; // Support up to 32 owned lands
-uniform int numOwnedLands;
 uniform float darkenFactor;
 uniform bool darkenOnlyWhenUnzoomed;
 uniform bool isUnzoomed;
+
+// Instanced buffer attributes (supports 60k+ lands)
+attribute float ownedState;
+attribute float outlineState;
+attribute vec3 outlineColor;
 
 varying float vHover;
 varying float vInstanceIndex;


### PR DESCRIPTION
wip: up max owned lands with instanced buffer attributes to shade unlimited number

fix gridsize for max owned lands

fix: clearing the owned lands when no owner

feat: unlimited hover and selected outline

feat: setting custom outlines where we want and custom color

fix: clearing outlines

add tools to test outlines persistency and clearing