### PR TITLE
fix reimburse stakes

### DIFF
--- a/contracts/src/components/stake.cairo
+++ b/contracts/src/components/stake.cairo
@@ -135,18 +135,17 @@ mod StakeComponent {
             self.token_ratios.read(token_address)
         }
 
-        fn _discount_total_stake(ref self: ComponentState<TContractState>, taxes: Span<TokenInfo>) {
-            for token_info in taxes {
-                let token_info = *token_info;
-                let current_total = self.token_stakes.read(token_info.token_address);
-                if current_total >= token_info.amount {
-                    self
-                        .token_stakes
-                        .write(token_info.token_address, current_total - token_info.amount);
-                } else {
-                    panic!("Attempting to discount more than what's staked");
-                }
-            };
+        fn _discount_stake_for_nuke(
+            ref self: ComponentState<TContractState>, token_info: TokenInfo,
+        ) {
+            let current_total = self.token_stakes.read(token_info.token_address);
+            if current_total >= token_info.amount {
+                self
+                    .token_stakes
+                    .write(token_info.token_address, current_total - token_info.amount);
+            } else {
+                panic!("Attempting to discount more than what's staked");
+            }
         }
 
         fn __generate_token_ratio(


### PR DESCRIPTION
### TL;DR

Refactored the land nuking mechanism to properly discount token stakes when lands are nuked.

### What changed?

- Replaced the generic `_discount_total_stake` method with a more specific `_discount_stake_for_nuke` method that handles a single token at a time
- Updated the land nuking process to track stake amounts before claiming and use these values when discounting from the total stake
- Added stake discounting in the `_delete_land_and_create_auction` method to ensure token stakes are properly updated when lands are nuked
- Added tracking of land stake before claim to properly handle stake discounting
- Added marking of staked lands as false in the staked_lands mapping when lands are nuked
- Enhanced the `test_reimburse_stakes` test to verify the functionality with multiple tokens

### How to test?

1. Run the updated `test_reimburse_stakes` test which now tests the functionality with multiple tokens
2. Verify that when lands are nuked, the total token stakes are properly discounted
3. Test the nuking process with different token types to ensure all stake amounts are correctly tracked and updated

### Why make this change?

This change fixes an issue where token stakes weren't being properly discounted when lands were nuked, which could lead to incorrect total stake calculations. The previous implementation didn't properly track and update the stake amounts during the nuking process, potentially leaving orphaned stake amounts in the system. This refactoring ensures that when lands are nuked, their stake amounts are correctly removed from the total token stakes.