### PR TITLE
fix: bug in refund stake

### DIFF
--- a/contracts/src/components/stake.cairo
+++ b/contracts/src/components/stake.cairo
@@ -90,9 +90,9 @@ mod StakeComponent {
             ref self: ComponentState<TContractState>,
             mut store: Store,
             land: Land,
+            ref land_stake: LandStake,
             our_contract_address: ContractAddress,
         ) {
-            let mut land_stake = store.land_stake(land.location);
             let stake_amount = land_stake.amount;
             assert(stake_amount > 0, 'amount to refund is 0');
             let mut payable = get_dep_component_mut!(ref self, Payable);
@@ -106,11 +106,8 @@ mod StakeComponent {
             assert(status, ERC20_REFUND_FAILED);
 
             let current_total = self.token_stakes.read(land.token_used);
-            if current_total >= stake_amount {
-                self.token_stakes.write(land.token_used, current_total - stake_amount);
-            } else {
-                panic!("Attempting to refund more than what's staked");
-            }
+            assert(current_total >= stake_amount, 'not sufficient to refund');
+            self.token_stakes.write(land.token_used, current_total - stake_amount);
 
             land_stake.amount = 0;
             store.set_land_stake(land_stake);

--- a/contracts/src/systems/actions.cairo
+++ b/contracts/src/systems/actions.cairo
@@ -291,7 +291,10 @@ pub mod actions {
                     our_contract_for_fee,
                 );
             self.validate_and_execute_buy_payment(land, caller, store, our_contract_for_fee);
-            self.stake._refund(store, land, our_contract_address);
+            let mut land_stake = store.land_stake(land.location);
+            if land_stake.amount > 0 {
+                self.stake._refund(store, land, ref land_stake, our_contract_address);
+            }
 
             self
                 .finalize_land_purchase(
@@ -777,8 +780,8 @@ pub mod actions {
         ) {
             let neighbors = get_land_neighbors(store, land.location);
 
-            if !has_liquidity_requirements && land_stake.amount >= 0 {
-                self.stake._refund(store, land, our_contract_address);
+            if !has_liquidity_requirements && land_stake.amount > 0 {
+                self.stake._refund(store, land, ref land_stake, our_contract_address);
                 land_stake = store.land_stake(land.location);
                 land_stake_before_claim = land_stake.amount;
             }


### PR DESCRIPTION
### TL;DR

Refactored the stake refund mechanism to improve safety and efficiency.

### What changed?

- Modified the `_refund` function in `StakeComponent` to accept a mutable reference to `land_stake` instead of fetching it inside the function
- Replaced a conditional block with an assertion to check if there's sufficient stake to refund
- Added a check in the calling functions to only call `_refund` when `land_stake.amount > 0`
- Fixed a condition in `actions.cairo` from `land_stake.amount >= 0` to `land_stake.amount > 0` to prevent unnecessary refund calls

### How to test?

1. Test buying land that has an existing stake to ensure the refund works correctly
2. Test claiming land with and without liquidity requirements to verify the refund logic
3. Verify that attempting to refund more than what's staked properly fails with the new assertion
4. Confirm that zero-amount stakes are properly handled and don't trigger refunds

### Why make this change?

This change improves code safety by:
1. Preventing unnecessary refund calls when stake amount is zero
2. Using a clearer assertion message for insufficient stake
3. Making the code more efficient by passing the already-loaded `land_stake` reference instead of loading it again
4. Ensuring consistent behavior when handling stake refunds across different operations