### PR TITLE
add client calcuation for auction current price

### DIFF
--- a/client/src/lib/api/land/index.ts
+++ b/client/src/lib/api/land/index.ts
@@ -88,7 +88,9 @@ export type LandWithActions = LandWithMeta & {
   claim(): TransactionResult;
   getNextClaim(): Promise<NextClaimInformation[] | undefined>;
   getNukable(): Promise<number | undefined>;
-  getCurrentAuctionPrice(): Promise<CurrencyAmount | undefined>;
+  getCurrentAuctionPrice(
+    useRpcForExactPrice?: boolean,
+  ): Promise<CurrencyAmount | undefined>;
   getYieldInfo(): Promise<LandYieldInfo | undefined>;
   getEstimatedNukeTime(): Promise<number | undefined>;
   getNeighbors(): Neighbors;

--- a/client/src/lib/components/+game-ui/widgets/land-info/buy/buy-sell-form.svelte
+++ b/client/src/lib/components/+game-ui/widgets/land-info/buy/buy-sell-form.svelte
@@ -57,8 +57,8 @@
 
     // Check if the land's current price is affordable
     if (land.type === 'auction') {
-      // For auction lands, get the current auction price
-      const currentAuctionPrice = await land.getCurrentAuctionPrice();
+      // For auction lands, get the current auction price (use client calc for validation)
+      const currentAuctionPrice = await land.getCurrentAuctionPrice(false);
       if (!currentAuctionPrice || !land.token) {
         error = 'Unable to get current auction price';
         return false;
@@ -83,7 +83,7 @@
     // Check if the total amount (stake + sell) is affordable
     let totalRequired;
     if (land.type === 'auction') {
-      const currentAuctionPrice = await land.getCurrentAuctionPrice();
+      const currentAuctionPrice = await land.getCurrentAuctionPrice(false);
       if (!currentAuctionPrice || !land.token) {
         error = 'Unable to get current auction price';
         return false;
@@ -100,7 +100,7 @@
     }
 
     if (selectedTokenBalance.rawValue().isLessThan(totalRequired)) {
-      error = `Insufficient balance. You need ${totalRequired} ${selectedToken.symbol} (stake: ${parsedStake}, ${land.type === 'auction' ? 'current auction price' : 'price'}: ${land.type === 'auction' ? (await land.getCurrentAuctionPrice())?.toString() : parsedSell}). Your balance: ${selectedTokenBalance.toString()} ${selectedToken.symbol}`;
+      error = `Insufficient balance. You need ${totalRequired} ${selectedToken.symbol} (stake: ${parsedStake}, ${land.type === 'auction' ? 'current auction price' : 'price'}: ${land.type === 'auction' ? (await land.getCurrentAuctionPrice(false))?.toString() : parsedSell}). Your balance: ${selectedTokenBalance.toString()} ${selectedToken.symbol}`;
       return false;
     }
 

--- a/client/src/lib/components/+game-ui/widgets/land-info/tabs/buy-tab.svelte
+++ b/client/src/lib/components/+game-ui/widgets/land-info/tabs/buy-tab.svelte
@@ -262,7 +262,8 @@
     let currentPrice: CurrencyAmount | undefined = land.sellPrice;
 
     if (land.type == 'auction') {
-      currentPrice = await land.getCurrentAuctionPrice();
+      // Use RPC for exact price when bidding to avoid approval issues
+      currentPrice = await land.getCurrentAuctionPrice(true);
     }
 
     console.log('baseToken', baseToken?.address);
@@ -477,7 +478,7 @@
         BUY FOR <span class="text-yellow-500">
           &nbsp;
           {#if land.type == 'auction'}
-            {#await land?.getCurrentAuctionPrice()}
+            {#await land?.getCurrentAuctionPrice(false)}
               fetching...
             {:then price}
               {price}

--- a/client/src/lib/stores/config.store.svelte.ts
+++ b/client/src/lib/stores/config.store.svelte.ts
@@ -14,6 +14,7 @@ export let configValues = $state({
   maxAuctions: 16,
   auctionDuration: 7 * 24 * 60 * 60,
   levelUpTime: 3600 * 48, // baseTime * 48
+  feeContract: null as string | null,
   // Auction price calculation parameters (from contract)
   linearDecayTime: 10 * 60 * 20, // Will be updated from contract
   dropRate: 90,
@@ -31,6 +32,7 @@ function updateConfigValues(newConfig: Config) {
   configValues.maxAuctions = Number(newConfig.max_auctions);
   configValues.auctionDuration = Number(newConfig.auction_duration);
   configValues.levelUpTime = configValues.baseTime * 48;
+  configValues.feeContract = addAddressPadding(newConfig.our_contract_for_fee);
   // Auction price calculation parameters
   configValues.linearDecayTime = Number(newConfig.linear_decay_time);
   configValues.dropRate = Number(newConfig.drop_rate);

--- a/client/src/lib/stores/config.store.svelte.ts
+++ b/client/src/lib/stores/config.store.svelte.ts
@@ -14,7 +14,12 @@ export let configValues = $state({
   maxAuctions: 16,
   auctionDuration: 7 * 24 * 60 * 60,
   levelUpTime: 3600 * 48, // baseTime * 48
-  feeContract: null as string | null,
+  // Auction price calculation parameters (from contract)
+  linearDecayTime: 10 * 60 * 20, // Will be updated from contract
+  dropRate: 90,
+  rateDenominator: 100,
+  decayRate: 100,
+  scalingFactor: 50,
 });
 
 // Function to update all config values - only mutate properties, don't reassign
@@ -26,7 +31,12 @@ function updateConfigValues(newConfig: Config) {
   configValues.maxAuctions = Number(newConfig.max_auctions);
   configValues.auctionDuration = Number(newConfig.auction_duration);
   configValues.levelUpTime = configValues.baseTime * 48;
-  configValues.feeContract = addAddressPadding(newConfig.our_contract_for_fee);
+  // Auction price calculation parameters
+  configValues.linearDecayTime = Number(newConfig.linear_decay_time);
+  configValues.dropRate = Number(newConfig.drop_rate);
+  configValues.rateDenominator = Number(newConfig.rate_denominator);
+  configValues.decayRate = Number(newConfig.decay_rate);
+  configValues.scalingFactor = Number(newConfig.scaling_factor);
 }
 
 // Setup function

--- a/client/src/lib/utils/clientCalculations.ts
+++ b/client/src/lib/utils/clientCalculations.ts
@@ -1,0 +1,81 @@
+/**
+ * Client-side calculations to reduce RPC calls
+ *
+ * This module ports Cairo contract logic to JavaScript to calculate
+ * auction prices and taxes locally instead of making RPC calls.
+ *
+ */
+
+import { configValues } from '$lib/stores/config.store.svelte';
+
+// Constants from contracts/src/consts.cairo
+const DECIMALS_FACTOR = BigInt('1000000000000000000'); // 1e18
+
+/**
+ * Calculate current auction price with decay
+ *
+ * @param startTimeSeconds Auction start time in seconds
+ * @param startPrice Starting price as string or BigNumberish
+ * @param floorPrice Floor price as string or BigNumberish
+ * @returns Current price as BigInt
+ */
+export function calculateAuctionPrice(
+  startTimeSeconds: number,
+  startPrice: bigint,
+  floorPrice: bigint,
+): bigint {
+  const currentTime = BigInt(Math.floor(Date.now() / 1000)); // Convert to seconds to match contract
+  const startTime = BigInt(startTimeSeconds);
+
+  // Calculate raw time difference first
+  const rawTimeDiff =
+    currentTime > startTime ? currentTime - startTime : BigInt(0);
+
+  // Apply game speed to get accelerated time
+  const timePassed = rawTimeDiff * BigInt(configValues.gameSpeed);
+
+  const startPriceBig = startPrice;
+  const floorPriceBig = floorPrice;
+
+  // If auction duration has passed, return floor price (not 0)
+  if (timePassed >= BigInt(configValues.auctionDuration)) {
+    return BigInt(0);
+  }
+
+  let currentPrice = startPriceBig;
+  const linearDecayTime = BigInt(configValues.linearDecayTime);
+  const dropRate = BigInt(configValues.dropRate);
+  const rateDenominator = BigInt(configValues.rateDenominator);
+  const decayRate = BigInt(configValues.decayRate);
+  const scalingFactor = BigInt(configValues.scalingFactor);
+  // Phase 1: Linear decay (first 10 minutes IRL)
+  if (timePassed <= linearDecayTime) {
+    const timeFraction = (timePassed * DECIMALS_FACTOR) / linearDecayTime;
+    const linearFactor =
+      DECIMALS_FACTOR - (dropRate * timeFraction) / rateDenominator;
+    currentPrice = (startPriceBig * linearFactor) / DECIMALS_FACTOR;
+  }
+  // Phase 2: Exponential decay
+  else {
+    const remainingRate = rateDenominator - dropRate;
+    const priceAfterLinear = (startPriceBig * remainingRate) / rateDenominator;
+    const progressTime =
+      (timePassed * DECIMALS_FACTOR) / BigInt(configValues.auctionDuration);
+    const k = (decayRate * DECIMALS_FACTOR) / scalingFactor;
+
+    const denominator = DECIMALS_FACTOR + (k * progressTime) / DECIMALS_FACTOR;
+
+    // Match Cairo implementation exactly: temp = (1e18 * 1e18) / denominator, then (temp * temp) / 1e18
+    const decayFactor =
+      denominator !== BigInt(0)
+        ? (() => {
+            const temp = (DECIMALS_FACTOR * DECIMALS_FACTOR) / denominator;
+            return (temp * temp) / DECIMALS_FACTOR;
+          })()
+        : BigInt(0);
+
+    currentPrice = (priceAfterLinear * decayFactor) / DECIMALS_FACTOR;
+  }
+
+  return currentPrice > floorPriceBig ? currentPrice : floorPriceBig;
+}


### PR DESCRIPTION
### TL;DR

Implemented client-side auction price calculation to reduce RPC calls and improve UI responsiveness.

### What changed?

- Added a new `clientCalculations.ts` utility that ports Cairo contract logic to JavaScript for calculating auction prices locally
- Modified `getCurrentAuctionPrice()` to accept an optional parameter `useRpcForExactPrice` that determines whether to use client-side calculation or RPC call
- Updated auction price calculation to use client-side logic by default for UI display, but RPC for exact pricing when bidding
- Added auction price calculation parameters to the config store (linearDecayTime, dropRate, rateDenominator, decayRate, scalingFactor)
- Updated UI components to use the new parameter when fetching auction prices

### How to test?

1. Navigate to an auction land in the game
2. Verify that the displayed auction price updates smoothly without constant RPC calls
3. Attempt to bid on an auction land to ensure the exact price is fetched from RPC when needed
4. Check browser console for logs indicating when RPC vs client calculation is being used

### Why make this change?

This optimization reduces the number of RPC calls needed for displaying auction prices in the UI, which improves performance and reduces network load. By calculating prices client-side for display purposes but still using RPC for exact pricing during bidding, we maintain accuracy where it matters while improving the user experience. This is particularly important for auction lands where prices decay over time and frequent updates are needed.