### PR TITLE
add client calculation for neighbors yield

### DIFF
--- a/client/src/lib/api/land/index.ts
+++ b/client/src/lib/api/land/index.ts
@@ -91,7 +91,9 @@ export type LandWithActions = LandWithMeta & {
   getCurrentAuctionPrice(
     useRpcForExactPrice?: boolean,
   ): Promise<CurrencyAmount | undefined>;
-  getYieldInfo(): Promise<LandYieldInfo | undefined>;
+  getYieldInfo(
+    useRpcForExactCalculation?: boolean,
+  ): Promise<LandYieldInfo | undefined>;
   getEstimatedNukeTime(): Promise<number | undefined>;
   getNeighbors(): Neighbors;
   levelUp(): TransactionResult;

--- a/client/src/lib/components/+game-map/land/hud/land-hud-info.svelte
+++ b/client/src/lib/components/+game-map/land/hud/land-hud-info.svelte
@@ -32,7 +32,8 @@
   let burnRate = $derived(
     CurrencyAmount.fromScaled(
       calculateBurnRate(
-        land as LandWithActions,
+        land.sellPrice,
+        land.level,
         getNumberOfNeighbours() || 0,
       ).toNumber(),
       land.token,
@@ -72,7 +73,7 @@
 
   $effect(() => {
     if (land == undefined) return;
-    land.getYieldInfo().then((info) => {
+    land.getYieldInfo(false).then((info) => {
       yieldInfo = info;
 
       let totalValue = 0;

--- a/client/src/lib/components/+game-map/land/land-rates-overlay.svelte
+++ b/client/src/lib/components/+game-map/land/land-rates-overlay.svelte
@@ -33,7 +33,9 @@
     yieldInfo.filter((info) => (info?.percent_rate ?? 0n) !== 0n).length,
   );
 
-  let tokenBurnRate = $derived(calculateBurnRate(land, numberOfNeighbours));
+  let tokenBurnRate = $derived(
+    calculateBurnRate(land.sellPrice, land.level, numberOfNeighbours),
+  );
 
   $effect(() => {
     if (land) {
@@ -48,7 +50,7 @@
       } else {
         isLoading = true;
         yieldInfo = [];
-        getNeighbourYieldArray(land).then((res) => {
+        getNeighbourYieldArray(land, false).then((res) => {
           yieldInfo = res;
           yieldInfo.splice(4, 0, null);
           isLoading = false;

--- a/client/src/lib/components/+game-ui/widgets/land-info/buy/buy-insights.svelte
+++ b/client/src/lib/components/+game-ui/widgets/land-info/buy/buy-insights.svelte
@@ -33,7 +33,7 @@
     if (sellAmountVal) {
       taxes = calculateTaxes(Number(sellAmountVal));
     } else {
-      taxes = Number(calculateBurnRate(land, 1));
+      taxes = Number(calculateBurnRate(land.sellPrice, land.level, 1));
     }
   });
 

--- a/client/src/lib/components/+game-ui/widgets/land-info/tabs/overall-tab.svelte
+++ b/client/src/lib/components/+game-ui/widgets/land-info/tabs/overall-tab.svelte
@@ -44,7 +44,7 @@
   let totalYieldValue: number = $state(0);
 
   let burnRate = $derived(
-    calculateBurnRate(land as LandWithActions, getNumberOfNeighbours() || 0),
+    calculateBurnRate(land.sellPrice, land.level, getNumberOfNeighbours() || 0),
   );
 
   let burnRateInBaseToken: CurrencyAmount = $state(
@@ -77,7 +77,7 @@
 
   $effect(() => {
     if (land == undefined) return;
-    land.getYieldInfo().then((info) => {
+    land.getYieldInfo(false).then((info) => {
       yieldInfo = info;
 
       let totalValue = 0;

--- a/client/src/lib/components/+game-ui/widgets/land-info/tax-impact/tax-impact.svelte
+++ b/client/src/lib/components/+game-ui/widgets/land-info/tax-impact/tax-impact.svelte
@@ -30,7 +30,7 @@
     if (sellAmountVal) {
       taxes = calculateTaxes(Number(sellAmountVal));
     } else {
-      taxes = Number(calculateBurnRate(land as LandWithActions, 1));
+      taxes = Number(calculateBurnRate(land.sellPrice, land.level, 1));
     }
   });
 

--- a/client/src/lib/components/tutorial/tutorial-land-store.ts
+++ b/client/src/lib/components/tutorial/tutorial-land-store.ts
@@ -301,7 +301,7 @@ export class TutorialLandStore extends LandTileStore {
 
   // Implement the method to calculate tax rate per neighbor
   getTaxRatePerNeighbor(neighbor: LandWithActions) {
-    return burnForOneNeighbor(neighbor);
+    return burnForOneNeighbor(neighbor.sellPrice);
   }
 
   setStake(amount: number = 100, x: number = 32, y: number = 32): void {

--- a/client/src/lib/interfaces.ts
+++ b/client/src/lib/interfaces.ts
@@ -67,7 +67,6 @@ export interface YieldInfo {
 
 export interface LandYieldInfo {
   yield_info: Array<YieldInfo>;
-  remaining_stake_time: bigint;
 }
 
 export interface ElapsedTimeSinceLastClaim {

--- a/client/src/lib/utils/land-actions.ts
+++ b/client/src/lib/utils/land-actions.ts
@@ -140,7 +140,7 @@ export const createLandWithActions = (
         try {
           // Get neighbors using the existing land method
           const neighbors = land.getNeighbors(landStore);
-          const neighborLands = neighbors.getNeighbors();
+          const neighborLands = neighbors.getBaseLandsArray();
 
           const calculatedYieldInfo = calculateYieldInfo(neighborLands);
 


### PR DESCRIPTION
### TL;DR

Added client-side yield calculation to reduce RPC calls and improve performance.

### What changed?

- Added a new `calculateYieldInfo` function in `clientCalculations.ts` that replicates the Cairo contract's yield calculation logic
- Modified `getYieldInfo()` to accept an optional `useRpcForExactCalculation` parameter that determines whether to use client-side calculation or RPC
- Updated `calculateBurnRate()` to accept individual parameters (sellPrice, level, neighborCount) instead of the entire land object
- Updated all references to these functions throughout the codebase

### How to test?

1. Open the game and navigate to different lands
2. Check that yield information displays correctly in the land HUD and info panels
3. Verify that client-side calculations match RPC results by comparing values with `useRpcForExactCalculation` set to true vs false
4. Monitor network requests to confirm fewer RPC calls are being made

### Why make this change?

This optimization reduces the number of RPC calls needed for displaying yield information, which improves performance and reduces server load. By performing calculations client-side when exact precision isn't required (like for UI displays), we can provide a more responsive experience while still allowing for exact calculations via RPC when needed for critical operations.