### PR TITLE
add functions for individual stake reimbursement

### DIFF
--- a/contracts/src/tests/setup.cairo
+++ b/contracts/src/tests/setup.cairo
@@ -129,6 +129,7 @@ mod setup {
                 TestResource::Event(
                     auth::e_AddressAuthorizedEvent::TEST_CLASS_HASH.try_into().unwrap(),
                 ),
+                TestResource::Event(auth::e_GameEndedEvent::TEST_CLASS_HASH.try_into().unwrap()),
                 TestResource::Event(
                     events::e_AuctionFinishedEvent::TEST_CLASS_HASH.try_into().unwrap(),
                 ),


### PR DESCRIPTION
### TL;DR

Refactored the stake withdrawal mechanism to allow individual land owners to withdraw their stakes after the game has ended, replacing the admin-only reimbursement function.

### What changed?

- Added a game ending mechanism in the `Auth` system with a new `end_game_and_enable_withdrawals` function that can only be called by the owner
- Replaced the admin-only `reimburse_stakes` function with two user-facing functions:
  - `withdraw_stake` - allows a land owner to withdraw stake from a single land
  - `withdraw_stakes_batch` - allows a land owner to withdraw stakes from multiple lands at once
- Refactored the `_reimburse` function in the `StakeComponent` to handle a single land instead of a span of lands
- Improved error messages and assertions for stake refund operations
- Removed the `staked_lands` map as it's no longer needed with the new withdrawal approach
- Added a new `GameEndedEvent` to track when the game is ended

### How to test?

- Added a comprehensive test case `test_withdrawal_functions` that:
  1. Sets up multiple lands with different owners and token types
  2. Ends the game using the new auth function
  3. Tests single land withdrawal with `withdraw_stake`
  4. Tests batch withdrawal with `withdraw_stakes_batch`
  5. Verifies that stakes are properly cleared and tokens are refunded to the correct owners

### Why make this change?

This change improves the user experience at the end of the game by:
1. Allowing individual land owners to withdraw their own stakes rather than relying on an admin to process all refunds
2. Providing a more gas-efficient withdrawal process where users can choose to withdraw stakes for one or multiple lands
3. Implementing a cleaner game ending mechanism that prevents further actions while enabling withdrawals
4. Ensuring that only land owners can withdraw their own stakes, improving security