### PR TITLE
add withdraw stake functions in the client

### DIFF
--- a/client/src/lib/contracts.gen.ts
+++ b/client/src/lib/contracts.gen.ts
@@ -2211,9 +2211,10 @@ export function setupWorld(provider: DojoProvider) {
       recreateAuction: actions_recreateAuction,
       buildRecreateAuctionCalldata: build_actions_recreateAuction_calldata,
       withdrawStake: actions_withdrawStake,
-			buildWithdrawStakeCalldata: build_actions_withdrawStake_calldata,
-			withdrawStakesBatch: actions_withdrawStakesBatch,
-			buildWithdrawStakesBatchCalldata: build_actions_withdrawStakesBatch_calldata,
+      buildWithdrawStakeCalldata: build_actions_withdrawStake_calldata,
+      withdrawStakesBatch: actions_withdrawStakesBatch,
+      buildWithdrawStakesBatchCalldata:
+        build_actions_withdrawStakesBatch_calldata,
     },
     auth: {
       addAuthorized: auth_addAuthorized,


### PR DESCRIPTION
### TL;DR

Replace `reimburseStakes` with new stake withdrawal functions that allow for more granular control.

### What changed?

- Removed `build_actions_reimburseStakes_calldata` and `actions_reimburseStakes` functions
- Added new functions for withdrawing stakes:
  - `build_actions_withdrawStake_calldata` and `actions_withdrawStake` for withdrawing a single stake
  - `build_actions_withdrawStakesBatch_calldata` and `actions_withdrawStakesBatch` for withdrawing multiple stakes at once
- The new functions accept specific land locations as parameters, allowing for targeted withdrawals


### Why make this change?

This change provides more flexibility in stake management by allowing users to withdraw stakes from specific land locations rather than having to reimburse all stakes at once. This granular control improves user experience and enables more targeted financial operations within the application.