### PR TITLE
fix: Fixed nonce issue in claimAll

### DIFF
--- a/client/src/lib/stores/claim.store.svelte.ts
+++ b/client/src/lib/stores/claim.store.svelte.ts
@@ -39,16 +39,17 @@ export async function claimAll(
       }),
     );
 
-    await sdk.client.actions
-      .claimAll(
-        account,
-        batch.map((land) => land.location as BigNumberish),
-      )
-      .then((value) => {
-        batchAggregatedTaxes.forEach((result) => {
-          handlePostClaim(batch, result, value.transaction_hash);
-        });
-      });
+    const txConfirmation = await sdk.client.actions.claimAll(
+      account,
+      batch.map((land) => land.location as BigNumberish),
+    );
+
+    batchAggregatedTaxes.forEach((result) => {
+      handlePostClaim(batch, result, txConfirmation.transaction_hash);
+    });
+
+    // Wait for the transaction to be confirmed before going to the next batch
+    await account.waitForTransaction(txConfirmation.transaction_hash);
   }
 }
 


### PR DESCRIPTION
This is due to the fact that we are not waiting for the transaction
to be committed on-chain before sending the next one, which could
be causing issues related to nonce management. This now waits
until the previous transaction is in fact committed before sending
the next one