### PR TITLE
feat:add to crates StakeAddEvent

### DIFF
--- a/crates/chaindata/models/src/events/actions/add_stake.rs
+++ b/crates/chaindata/models/src/events/actions/add_stake.rs
@@ -1,0 +1,27 @@
+use ponziland_models::events::actions::AddStakeEvent;
+use serde::{Deserialize, Serialize};
+use sqlx::prelude::FromRow;
+
+use crate::{
+    events::EventId,
+    shared::{Location, U256},
+};
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct AddStakeEventModel {
+    pub id: Option<EventId>,
+    pub location: Location,
+    pub new_stake_amount: U256,
+    pub owner: String,
+}
+
+impl From<AddStakeEvent> for AddStakeEventModel {
+    fn from(event: AddStakeEvent) -> Self {
+        Self {
+            id: None,
+            location: event.land_location.into(),
+            new_stake_amount: event.new_stake_amount.into(),
+            owner: format!("{:#x}", event.owner),
+        }
+    }
+}

--- a/crates/chaindata/models/src/events/actions/mod.rs
+++ b/crates/chaindata/models/src/events/actions/mod.rs
@@ -1,9 +1,11 @@
+mod add_stake;
 mod auction_finished;
 mod land_bought;
 mod land_nuked;
 mod land_transfer;
 mod new_auction;
 
+pub use add_stake::AddStakeEventModel;
 pub use auction_finished::AuctionFinishedEventModel;
 pub use land_bought::LandBoughtEventModel;
 pub use land_nuked::LandNukedEventModel;

--- a/crates/chaindata/models/src/events/event.rs
+++ b/crates/chaindata/models/src/events/event.rs
@@ -1,6 +1,6 @@
 use super::{
     actions::{
-        AuctionFinishedEventModel, LandBoughtEventModel, LandNukedEventModel,
+        AddStakeEventModel, AuctionFinishedEventModel, LandBoughtEventModel, LandNukedEventModel,
         LandTransferEventModel, NewAuctionEventModel,
     },
     auth::{AddressAuthorizedEventModel, AddressRemovedEventModel, VerifierUpdatedEventModel},
@@ -18,6 +18,7 @@ pub struct Event {
 
 #[derive(Clone, Debug)]
 pub enum DataModel {
+    AddStake(AddStakeEventModel),
     AuctionFinished(AuctionFinishedEventModel),
     LandBought(LandBoughtEventModel),
     LandNuked(LandNukedEventModel),
@@ -31,6 +32,7 @@ pub enum DataModel {
 impl DataModel {
     pub fn set_id(&mut self, id: Id) {
         match self {
+            DataModel::AddStake(model) => model.id = Some(id),
             DataModel::AuctionFinished(model) => model.id = Some(id),
             DataModel::LandBought(model) => model.id = Some(id),
             DataModel::LandNuked(model) => model.id = Some(id),
@@ -46,6 +48,7 @@ impl DataModel {
 impl From<EventData> for DataModel {
     fn from(data: EventData) -> Self {
         match data {
+            EventData::AddStake(data) => DataModel::AddStake(data.into()),
             EventData::AuctionFinished(data) => DataModel::AuctionFinished(data.into()),
             EventData::LandBought(data) => DataModel::LandBought(data.into()),
             EventData::LandNuked(data) => DataModel::LandNuked(data.into()),

--- a/crates/chaindata/models/src/events/event_types.rs
+++ b/crates/chaindata/models/src/events/event_types.rs
@@ -5,6 +5,8 @@ use super::EventDataModel;
 #[derive(Clone, Debug, PartialEq, PartialOrd, sqlx::Type, Deserialize, Serialize)]
 #[sqlx(type_name = "event_type")]
 pub enum EventType {
+    #[sqlx(rename = "ponzi_land-AddStakeEvent")]
+    AddStake,
     #[sqlx(rename = "ponzi_land-AuctionFinishedEvent")]
     AuctionFinished,
     #[sqlx(rename = "ponzi_land-LandBoughtEvent")]
@@ -26,6 +28,7 @@ pub enum EventType {
 impl From<&EventDataModel> for EventType {
     fn from(value: &EventDataModel) -> Self {
         match value {
+            EventDataModel::AddStake(_) => EventType::AddStake,
             EventDataModel::AuctionFinished(_) => EventType::AuctionFinished,
             EventDataModel::LandBought(_) => EventType::LandBought,
             EventDataModel::LandNuked(_) => EventType::LandNuked,

--- a/crates/chaindata/repository/src/events/base.rs
+++ b/crates/chaindata/repository/src/events/base.rs
@@ -16,6 +16,7 @@ impl EventDataRepository {
         Conn: 'e + sqlx::Executor<'e, Database = sqlx::Postgres>,
     {
         match event.clone() {
+            EventDataModel::AddStake(event) => Self::save_event(conn, event),
             EventDataModel::AuctionFinished(event) => Self::save_event(conn, event),
             EventDataModel::LandBought(event) => Self::save_event(conn, event),
             EventDataModel::LandNuked(event) => Self::save_event(conn, event),

--- a/crates/chaindata/repository/src/events/event_data.rs
+++ b/crates/chaindata/repository/src/events/event_data.rs
@@ -2,7 +2,7 @@
 
 use chaindata_models::events::{
     actions::{
-        AuctionFinishedEventModel, LandBoughtEventModel, LandNukedEventModel,
+        AddStakeEventModel, AuctionFinishedEventModel, LandBoughtEventModel, LandNukedEventModel,
         LandTransferEventModel, NewAuctionEventModel,
     },
     auth::{AddressAuthorizedEventModel, AddressRemovedEventModel, VerifierUpdatedEventModel},
@@ -106,6 +106,13 @@ macro_rules! implement_repository {
         )*
     };
 }
+
+implement_repository!(AddStakeEventModel, "event_add_stake", {
+    id,
+    location,
+    new_stake_amount,
+    owner
+});
 
 implement_repository!(AuctionFinishedEventModel, "event_auction_finished", {
     id,

--- a/crates/migrations/sql/0005_add-stake-event.sql
+++ b/crates/migrations/sql/0005_add-stake-event.sql
@@ -1,0 +1,10 @@
+-- Add AddStakeEvent type to event_type enum
+ALTER TYPE event_type ADD VALUE 'ponzi_land-AddStakeEvent';
+
+-- Create table for AddStakeEvent
+CREATE TABLE event_add_stake (
+    id TEXT NOT NULL PRIMARY KEY,
+    location INT4 NOT NULL,
+    new_stake_amount uint_256 NOT NULL,
+    owner TEXT NOT NULL
+);

--- a/crates/ponziland-models/src/events/actions/add_stake.rs
+++ b/crates/ponziland-models/src/events/actions/add_stake.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+use torii_ingester::{
+    error::ToriiConversionError,
+    get,
+    prelude::{ContractAddress, Struct},
+    u256::U256,
+};
+
+use crate::shared::Location;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AddStakeEvent {
+    pub land_location: Location,
+    pub new_stake_amount: U256,
+    pub owner: ContractAddress,
+}
+
+impl TryFrom<Struct> for AddStakeEvent {
+    type Error = ToriiConversionError;
+
+    fn try_from(entity: Struct) -> Result<Self, Self::Error> {
+        Ok(Self {
+            land_location: get!(entity, "land_location", Location)?,
+            new_stake_amount: get!(entity, "new_stake_amount", U256)?,
+            owner: get!(entity, "owner", ContractAddress)?,
+        })
+    }
+}

--- a/crates/ponziland-models/src/events/actions/mod.rs
+++ b/crates/ponziland-models/src/events/actions/mod.rs
@@ -1,9 +1,11 @@
+mod add_stake;
 mod auction_finished;
 mod land_bought;
 mod land_nuked;
 mod land_transfer;
 mod new_auction;
 
+pub use add_stake::AddStakeEvent;
 pub use auction_finished::AuctionFinishedEvent;
 pub use land_bought::LandBoughtEvent;
 pub use land_nuked::LandNukedEvent;

--- a/crates/ponziland-models/src/events/event.rs
+++ b/crates/ponziland-models/src/events/event.rs
@@ -3,12 +3,14 @@ use torii_ingester::prelude::Struct;
 use torii_ingester::{error::ToriiConversionError, RawToriiData};
 
 use super::actions::{
-    AuctionFinishedEvent, LandBoughtEvent, LandNukedEvent, LandTransferEvent, NewAuctionEvent,
+    AddStakeEvent, AuctionFinishedEvent, LandBoughtEvent, LandNukedEvent, LandTransferEvent,
+    NewAuctionEvent,
 };
 use super::auth::{AddressAuthorizedEvent, AddressRemovedEvent, VerifierUpdatedEvent};
 
 #[derive(Clone, Debug)]
 pub enum EventData {
+    AddStake(AddStakeEvent),
     AuctionFinished(AuctionFinishedEvent),
     LandBought(LandBoughtEvent),
     LandNuked(LandNukedEvent),
@@ -69,6 +71,7 @@ impl EventData {
     /// Returns an error if the JSON value cannot be deserialized into the corresponding event data.
     pub fn from_json(name: &str, json: Value) -> Result<Self, ToriiConversionError> {
         Ok(match name {
+            "ponzi_land-AddStakeEvent" => EventData::AddStake(serde_json::from_value(json)?),
             "ponzi_land-AuctionFinishedEvent" => {
                 EventData::AuctionFinished(serde_json::from_value(json)?)
             }
@@ -99,6 +102,9 @@ impl TryFrom<Struct> for EventData {
     type Error = ToriiConversionError;
     fn try_from(value: Struct) -> Result<Self, Self::Error> {
         Ok(match &*value.name {
+            "ponzi_land-AddStakeEvent" => {
+                EventData::AddStake(AddStakeEvent::try_from(value)?)
+            }
             "ponzi_land-AuctionFinishedEvent" => {
                 EventData::AuctionFinished(AuctionFinishedEvent::try_from(value)?)
             }


### PR DESCRIPTION
### TL;DR

Added support for the `AddStakeEvent` to track when users add stake to land.

### What changed?

- Created new `AddStakeEvent` model in `ponziland-models` to represent the event emitted when a user adds stake to land
- Added corresponding `AddStakeEventModel` in `chaindata/models` for database representation
- Updated event type enums and repositories to handle the new event type
- Created a database migration (`0005_add-stake-event.sql`) that:
  - Adds the new event type to the `event_type` enum
  - Creates a new `event_add_stake` table with fields for id, location, new_stake_amount, and owner

### How to test?

1. Run the migration to update the database schema
2. Trigger an AddStake event on the blockchain
3. Verify the event is properly captured, processed, and stored in the database
4. Query the `event_add_stake` table to confirm the data is correctly stored

### Why make this change?

This change enables tracking when users add stake to land, which is an important economic action in the system. Storing this data allows for better analytics, user history tracking, and integration with other platform features that depend on stake information.