### PR TITLE
update-repository-for-pnl

### DIFF
--- a/crates/chaindata/repository/Cargo.toml
+++ b/crates/chaindata/repository/Cargo.toml
@@ -15,6 +15,7 @@ sqlx = { workspace = true, features = [
     "bigdecimal",
 ] }
 chaindata-models = { path = "../models" }
+serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/chaindata/repository/src/event.rs
+++ b/crates/chaindata/repository/src/event.rs
@@ -1,6 +1,6 @@
 use crate::{events::base::EventDataRepository, Database, Error};
 use chaindata_models::events::{Event, EventId, EventType, FetchedEvent};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use sqlx::{query, query_as};
 
 pub struct Repository {
@@ -56,6 +56,120 @@ impl Repository {
         .await?
         .max
         .map_or(DateTime::UNIX_EPOCH, |date| date.and_utc()))
+    }
+
+    /// Get events after a specific timestamp.
+    ///
+    /// # Errors
+    /// Returns an error if the events could not be fetched.
+    pub async fn get_events_after(&self, after: NaiveDateTime) -> Result<Vec<FetchedEvent>, Error> {
+        // Get event IDs first
+        let event_ids = query!(
+            r#"
+            SELECT id as "id: EventId"
+            FROM event
+            WHERE at > $1
+            ORDER BY at ASC
+            "#,
+            after
+        )
+        .fetch_all(&mut *(self.db.acquire().await?))
+        .await?;
+
+        // For each event ID, fetch the full event data
+        let mut events = Vec::new();
+        for event_id in event_ids {
+            // Get the base event
+            let base_event = query_as!(
+                Event,
+                r#"
+                SELECT
+                    id as "id: _",
+                    at,
+                    event_type as "event_type: _"
+                FROM event
+                WHERE id = $1
+                "#,
+                event_id.id as EventId
+            )
+            .fetch_one(&mut *(self.db.acquire().await?))
+            .await?;
+
+            // Get the event data by trying each event type
+            let event_data = self.get_event_data_by_id(&base_event.id, &base_event.event_type).await?;
+
+            events.push(FetchedEvent {
+                id: base_event.id,
+                at: base_event.at,
+                data: event_data,
+            });
+        }
+
+        Ok(events)
+    }
+
+    /// Helper method to get event data by ID and type
+    ///
+    /// # Errors
+    /// Returns an error if the event data could not be fetched.
+    async fn get_event_data_by_id(
+        &self,
+        event_id: &EventId,
+        event_type: &EventType,
+    ) -> Result<chaindata_models::events::EventDataModel, Error> {
+        use chaindata_models::events::EventDataModel;
+        use crate::events::event_data::EventModelRepository;
+
+        // Match on event_type to know which table to query
+        match event_type {
+            EventType::AddStake => {
+                if let Some(event) = <EventDataRepository as EventModelRepository<chaindata_models::events::actions::AddStakeEventModel>>::get_by_id(&mut *(self.db.acquire().await?), event_id.clone()).await? {
+                    return Ok(EventDataModel::AddStake(event));
+                }
+            }
+            EventType::AuctionFinished => {
+                if let Some(event) = <EventDataRepository as EventModelRepository<chaindata_models::events::actions::AuctionFinishedEventModel>>::get_by_id(&mut *(self.db.acquire().await?), event_id.clone()).await? {
+                    return Ok(EventDataModel::AuctionFinished(event));
+                }
+            }
+            EventType::LandBought => {
+                if let Some(event) = <EventDataRepository as EventModelRepository<chaindata_models::events::actions::LandBoughtEventModel>>::get_by_id(&mut *(self.db.acquire().await?), event_id.clone()).await? {
+                    return Ok(EventDataModel::LandBought(event));
+                }
+            }
+            EventType::LandNuked => {
+                if let Some(event) = <EventDataRepository as EventModelRepository<chaindata_models::events::actions::LandNukedEventModel>>::get_by_id(&mut *(self.db.acquire().await?), event_id.clone()).await? {
+                    return Ok(EventDataModel::LandNuked(event));
+                }
+            }
+            EventType::NewAuction => {
+                if let Some(event) = <EventDataRepository as EventModelRepository<chaindata_models::events::actions::NewAuctionEventModel>>::get_by_id(&mut *(self.db.acquire().await?), event_id.clone()).await? {
+                    return Ok(EventDataModel::NewAuction(event));
+                }
+            }
+            EventType::AddressAuthorized => {
+                if let Some(event) = <EventDataRepository as EventModelRepository<chaindata_models::events::auth::AddressAuthorizedEventModel>>::get_by_id(&mut *(self.db.acquire().await?), event_id.clone()).await? {
+                    return Ok(EventDataModel::AddressAuthorized(event));
+                }
+            }
+            EventType::AddressRemoved => {
+                if let Some(event) = <EventDataRepository as EventModelRepository<chaindata_models::events::auth::AddressRemovedEventModel>>::get_by_id(&mut *(self.db.acquire().await?), event_id.clone()).await? {
+                    return Ok(EventDataModel::AddressRemoved(event));
+                }
+            }
+            EventType::VerifierUpdated => {
+                if let Some(event) = <EventDataRepository as EventModelRepository<chaindata_models::events::auth::VerifierUpdatedEventModel>>::get_by_id(&mut *(self.db.acquire().await?), event_id.clone()).await? {
+                    return Ok(EventDataModel::VerifierUpdated(event));
+                }
+            }
+            EventType::LandTransfer => {
+                if let Some(event) = <EventDataRepository as EventModelRepository<chaindata_models::events::actions::LandTransferEventModel>>::get_by_id(&mut *(self.db.acquire().await?), event_id.clone()).await? {
+                    return Ok(EventDataModel::LandTransfer(event));
+                }
+            }
+        }
+
+        Err(sqlx::Error::RowNotFound.into())
     }
 
     /// Saves an event into the database.

--- a/crates/chaindata/repository/src/land.rs
+++ b/crates/chaindata/repository/src/land.rs
@@ -149,6 +149,34 @@ impl Repository {
         .map(|row| row.latest_time)
     }
 
+    /// Gets land by location (latest version)
+    ///
+    /// # Errors
+    /// Returns an error if the land could not be retrieved
+    pub async fn get_by_location(&self, location: Location) -> Result<LandModel, sqlx::Error> {
+        query_as!(
+            LandModel,
+            r#"
+            SELECT
+                id as "id: _",
+                at,
+                location as "location: Location",
+                bought_at,
+                owner,
+                sell_price as "sell_price: _",
+                token_used,
+                level as "level: _"
+            FROM land
+            WHERE location = $1
+            ORDER BY at DESC
+            LIMIT 1
+            "#,
+            location as Location
+        )
+        .fetch_one(&mut *(self.db.acquire().await?))
+        .await
+    }
+
     /// Gets the total distribution of tokens for all lands
     ///
     /// # Errors

--- a/crates/chaindata/repository/src/land_position.rs
+++ b/crates/chaindata/repository/src/land_position.rs
@@ -1,0 +1,294 @@
+use crate::{Database, Error};
+use chaindata_models::models::LandPosition;
+use chaindata_models::shared::Location;
+use sqlx::{query, query_as};
+
+pub struct Repository {
+    db: Database,
+}
+
+impl Repository {
+    #[must_use]
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Create a new position
+    ///
+    /// # Errors
+    /// Returns an error if the position could not be created.
+    pub async fn create_position(&self, position: &LandPosition) -> Result<i32, Error> {
+        let position_id = query!(
+            r#"
+            INSERT INTO land_position (
+                land_location, owner_address, token_used,
+                entry_price, entry_token, entry_type, entry_timestamp, entry_event_id,
+                initial_stake, total_stake_added,
+                taxes_earned_by_token, taxes_paid_amount,
+                total_buy_fee, total_claim_fees,
+                status, value_in_usdc
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+            RETURNING position_id
+            "#,
+            position.land_location as Location,
+            position.owner_address,
+            position.token_used,
+            position.entry_price as _,
+            position.entry_token,
+            position.entry_type as _,
+            position.entry_timestamp,
+            position.entry_event_id as _,
+            position.initial_stake as _,
+            position.total_stake_added as _,
+            position.taxes_earned_by_token,
+            position.taxes_paid_amount as _,
+            position.total_buy_fee as _,
+            position.total_claim_fees as _,
+            position.status as _,
+            position.value_in_usdc as _
+        )
+        .fetch_one(&mut *(self.db.acquire().await?))
+        .await?
+        .position_id;
+
+        Ok(position_id)
+    }
+
+    /// Get active position by owner and location
+    ///
+    /// # Errors
+    /// Returns an error if the query fails.
+    pub async fn get_active_by_owner_and_location(
+        &self,
+        owner: &str,
+        location: Location,
+    ) -> Result<Option<LandPosition>, Error> {
+        let position = query_as!(
+            LandPosition,
+            r#"
+            SELECT
+                position_id,
+                land_location as "land_location: _",
+                owner_address,
+                token_used,
+                entry_price as "entry_price: _",
+                entry_token,
+                entry_type as "entry_type: _",
+                entry_timestamp,
+                entry_event_id as "entry_event_id: _",
+                initial_stake as "initial_stake: _",
+                total_stake_added as "total_stake_added: _",
+                taxes_earned_by_token,
+                taxes_paid_amount as "taxes_paid_amount: _",
+                total_buy_fee as "total_buy_fee: _",
+                total_claim_fees as "total_claim_fees: _",
+                exit_price as "exit_price: _",
+                stake_refunded as "stake_refunded: _",
+                exit_timestamp,
+                exit_type as "exit_type: _",
+                exit_event_id as "exit_event_id: _",
+                status as "status: _",
+                value_in_usdc as "value_in_usdc: _"
+            FROM land_position
+            WHERE owner_address = $1 AND land_location = $2 AND status = 'ACTIVE'
+            "#,
+            owner,
+            location as Location
+        )
+        .fetch_optional(&mut *(self.db.acquire().await?))
+        .await?;
+
+        Ok(position)
+    }
+
+    /// Get all active positions by owner
+    ///
+    /// # Errors
+    /// Returns an error if the query fails.
+    pub async fn get_active_by_owner(&self, owner: &str) -> Result<Vec<LandPosition>, Error> {
+        let positions = query_as!(
+            LandPosition,
+            r#"
+            SELECT
+                position_id,
+                land_location as "land_location: _",
+                owner_address,
+                token_used,
+                entry_price as "entry_price: _",
+                entry_token,
+                entry_type as "entry_type: _",
+                entry_timestamp,
+                entry_event_id as "entry_event_id: _",
+                initial_stake as "initial_stake: _",
+                total_stake_added as "total_stake_added: _",
+                taxes_earned_by_token,
+                taxes_paid_amount as "taxes_paid_amount: _",
+                total_buy_fee as "total_buy_fee: _",
+                total_claim_fees as "total_claim_fees: _",
+                exit_price as "exit_price: _",
+                stake_refunded as "stake_refunded: _",
+                exit_timestamp,
+                exit_type as "exit_type: _",
+                exit_event_id as "exit_event_id: _",
+                status as "status: _",
+                value_in_usdc as "value_in_usdc: _"
+            FROM land_position
+            WHERE owner_address = $1 AND status = 'ACTIVE'
+            ORDER BY entry_timestamp DESC
+            "#,
+            owner
+        )
+        .fetch_all(&mut *(self.db.acquire().await?))
+        .await?;
+
+        Ok(positions)
+    }
+
+    /// Get all closed positions by owner
+    ///
+    /// # Errors
+    /// Returns an error if the query fails.
+    pub async fn get_closed_by_owner(&self, owner: &str) -> Result<Vec<LandPosition>, Error> {
+        let positions = query_as!(
+            LandPosition,
+            r#"
+            SELECT
+                position_id,
+                land_location as "land_location: _",
+                owner_address,
+                token_used,
+                entry_price as "entry_price: _",
+                entry_token,
+                entry_type as "entry_type: _",
+                entry_timestamp,
+                entry_event_id as "entry_event_id: _",
+                initial_stake as "initial_stake: _",
+                total_stake_added as "total_stake_added: _",
+                taxes_earned_by_token,
+                taxes_paid_amount as "taxes_paid_amount: _",
+                total_buy_fee as "total_buy_fee: _",
+                total_claim_fees as "total_claim_fees: _",
+                exit_price as "exit_price: _",
+                stake_refunded as "stake_refunded: _",
+                exit_timestamp,
+                exit_type as "exit_type: _",
+                exit_event_id as "exit_event_id: _",
+                status as "status: _",
+                value_in_usdc as "value_in_usdc: _"
+            FROM land_position
+            WHERE owner_address = $1 AND status = 'CLOSED'
+            ORDER BY exit_timestamp DESC
+            "#,
+            owner
+        )
+        .fetch_all(&mut *(self.db.acquire().await?))
+        .await?;
+
+        Ok(positions)
+    }
+
+    /// Update aggregates (stake, taxes, fees) for a position
+    ///
+    /// # Errors
+    /// Returns an error if the update fails.
+    pub async fn update_aggregates(
+        &self,
+        position_id: i32,
+        total_stake_added: Option<&chaindata_models::shared::U256>,
+        taxes_earned_by_token: Option<&serde_json::Value>,
+        taxes_paid_amount: Option<&chaindata_models::shared::U256>,
+        total_buy_fee: Option<&chaindata_models::shared::U256>,
+        total_claim_fees: Option<&chaindata_models::shared::U256>,
+        value_in_usdc: Option<&chaindata_models::shared::U256>,
+    ) -> Result<(), Error> {
+        let mut query_builder = sqlx::QueryBuilder::new("UPDATE land_position SET position_id = position_id");
+
+        let mut has_updates = false;
+
+        if let Some(stake) = total_stake_added {
+            query_builder.push(", total_stake_added = ");
+            query_builder.push_bind(stake);
+            has_updates = true;
+        }
+
+        if let Some(taxes) = taxes_earned_by_token {
+            query_builder.push(", taxes_earned_by_token = ");
+            query_builder.push_bind(taxes);
+            has_updates = true;
+        }
+
+        if let Some(taxes_paid) = taxes_paid_amount {
+            query_builder.push(", taxes_paid_amount = ");
+            query_builder.push_bind(taxes_paid);
+            has_updates = true;
+        }
+
+        if let Some(fee) = total_buy_fee {
+            query_builder.push(", total_buy_fee = ");
+            query_builder.push_bind(fee);
+            has_updates = true;
+        }
+
+        if let Some(fees) = total_claim_fees {
+            query_builder.push(", total_claim_fees = ");
+            query_builder.push_bind(fees);
+            has_updates = true;
+        }
+
+        if let Some(value) = value_in_usdc {
+            query_builder.push(", value_in_usdc = ");
+            query_builder.push_bind(value);
+            has_updates = true;
+        }
+
+        if !has_updates {
+            return Ok(());
+        }
+
+        query_builder.push(" WHERE position_id = ");
+        query_builder.push_bind(position_id);
+
+        let query = query_builder.build();
+        query.execute(&mut *(self.db.acquire().await?)).await?;
+
+        Ok(())
+    }
+
+    /// Close a position
+    ///
+    /// # Errors
+    /// Returns an error if the update fails.
+    pub async fn close_position(
+        &self,
+        position_id: i32,
+        exit_price: &chaindata_models::shared::U256,
+        stake_refunded: &chaindata_models::shared::U256,
+        exit_timestamp: &chrono::NaiveDateTime,
+        exit_type: &chaindata_models::models::ExitType,
+        exit_event_id: &chaindata_models::events::EventId,
+    ) -> Result<(), Error> {
+        query!(
+            r#"
+            UPDATE land_position
+            SET exit_price = $1,
+                stake_refunded = $2,
+                exit_timestamp = $3,
+                exit_type = $4,
+                exit_event_id = $5,
+                status = 'CLOSED'
+            WHERE position_id = $6
+            "#,
+            exit_price as _,
+            stake_refunded as _,
+            exit_timestamp,
+            exit_type as _,
+            exit_event_id as _,
+            position_id
+        )
+        .execute(&mut *(self.db.acquire().await?))
+        .await?;
+
+        Ok(())
+    }
+}

--- a/crates/chaindata/repository/src/land_stake.rs
+++ b/crates/chaindata/repository/src/land_stake.rs
@@ -151,6 +151,33 @@ impl Repository {
         .await
         .map(|row| row.latest_time)
     }
+
+    /// Gets land stake by location (latest version)
+    ///
+    /// # Errors
+    /// Returns an error if the land stake could not be retrieved
+    pub async fn get_by_location(&self, location: Location) -> Result<LandStakeModel, sqlx::Error> {
+        query_as!(
+            LandStakeModel,
+            r#"
+            SELECT
+                id as "id: _",
+                at,
+                location as "location: Location",
+                earliest_claim_neighbor_time,
+                earliest_claim_neighbor_location as "earliest_claim_neighbor_location: Location",
+                num_active_neighbors as "num_active_neighbors: i16",
+                amount as "amount: _"
+            FROM land_stake
+            WHERE location = $1
+            ORDER BY at DESC
+            LIMIT 1
+            "#,
+            location as Location
+        )
+        .fetch_one(&mut *(self.db.acquire().await?))
+        .await
+    }
 }
 
 #[cfg(test)]

--- a/crates/chaindata/repository/src/lib.rs
+++ b/crates/chaindata/repository/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod event;
 pub mod events;
 pub mod land;
+pub mod land_position;
 pub mod land_stake;
+pub mod pnl_processor_state;
+pub mod position_event_log;
 
 mod error;
 
@@ -9,4 +12,7 @@ pub type Database = sqlx::PgPool;
 pub use error::Error;
 pub use event::Repository as EventRepository;
 pub use land::Repository as LandRepository;
+pub use land_position::Repository as LandPositionRepository;
 pub use land_stake::Repository as LandStakeRepository;
+pub use pnl_processor_state::Repository as PnlProcessorStateRepository;
+pub use position_event_log::Repository as PositionEventLogRepository;

--- a/crates/chaindata/repository/src/pnl_processor_state.rs
+++ b/crates/chaindata/repository/src/pnl_processor_state.rs
@@ -1,0 +1,61 @@
+use crate::{Database, Error};
+use chaindata_models::models::PnlProcessorState;
+use sqlx::query_as;
+
+pub struct Repository {
+    db: Database,
+}
+
+impl Repository {
+    #[must_use]
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Get the last processed state
+    ///
+    /// # Errors
+    /// Returns an error if the query fails.
+    pub async fn get_last_processed(&self) -> Result<PnlProcessorState, Error> {
+        let state = query_as!(
+            PnlProcessorState,
+            r#"
+            SELECT
+                id,
+                last_processed_timestamp as "last_processed_timestamp!",
+                last_processed_event_id as "last_processed_event_id: _"
+            FROM pnl_processor_state
+            WHERE id = 1
+            "#,
+        )
+        .fetch_one(&mut *(self.db.acquire().await?))
+        .await?;
+
+        Ok(state)
+    }
+
+    /// Update the last processed state
+    ///
+    /// # Errors
+    /// Returns an error if the update fails.
+    pub async fn update_last_processed(
+        &self,
+        last_processed_timestamp: &chrono::NaiveDateTime,
+        last_processed_event_id: Option<&chaindata_models::events::EventId>,
+    ) -> Result<(), Error> {
+        sqlx::query!(
+            r#"
+            UPDATE pnl_processor_state
+            SET last_processed_timestamp = $1,
+                last_processed_event_id = $2
+            WHERE id = 1
+            "#,
+            last_processed_timestamp,
+            last_processed_event_id as _,
+        )
+        .execute(&mut *(self.db.acquire().await?))
+        .await?;
+
+        Ok(())
+    }
+}

--- a/crates/chaindata/repository/src/position_event_log.rs
+++ b/crates/chaindata/repository/src/position_event_log.rs
@@ -1,0 +1,87 @@
+use crate::{Database, Error};
+use chaindata_models::models::PositionEventLog;
+use sqlx::query_as;
+
+pub struct Repository {
+    db: Database,
+}
+
+impl Repository {
+    #[must_use]
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Append a log entry to the position event log
+    ///
+    /// # Errors
+    /// Returns an error if the log entry could not be created.
+    pub async fn append_log(&self, log: &PositionEventLog) -> Result<i32, Error> {
+        let log_id = sqlx::query!(
+            r#"
+            INSERT INTO position_event_log (
+                position_id, event_type, event_data, timestamp, blockchain_event_id
+            )
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING log_id
+            "#,
+            log.position_id,
+            log.event_type,
+            log.event_data,
+            log.timestamp,
+            log.blockchain_event_id as _
+        )
+        .fetch_one(&mut *(self.db.acquire().await?))
+        .await?
+        .log_id;
+
+        Ok(log_id)
+    }
+
+    /// Get all logs for a position
+    ///
+    /// # Errors
+    /// Returns an error if the query fails.
+    pub async fn get_logs_by_position(&self, position_id: i32) -> Result<Vec<PositionEventLog>, Error> {
+        let logs = query_as!(
+            PositionEventLog,
+            r#"
+            SELECT
+                log_id,
+                position_id,
+                event_type,
+                event_data,
+                timestamp as "timestamp!",
+                blockchain_event_id as "blockchain_event_id: _"
+            FROM position_event_log
+            WHERE position_id = $1
+            ORDER BY timestamp ASC
+            "#,
+            position_id
+        )
+        .fetch_all(&mut *(self.db.acquire().await?))
+        .await?;
+
+        Ok(logs)
+    }
+
+    /// Check if an event has already been processed (idempotency check)
+    ///
+    /// # Errors
+    /// Returns an error if the query fails.
+    pub async fn is_event_processed(&self, blockchain_event_id: &chaindata_models::events::EventId) -> Result<bool, Error> {
+        let result = sqlx::query!(
+            r#"
+            SELECT log_id
+            FROM position_event_log
+            WHERE blockchain_event_id = $1
+            LIMIT 1
+            "#,
+            blockchain_event_id as _
+        )
+        .fetch_optional(&mut *(self.db.acquire().await?))
+        .await?;
+
+        Ok(result.is_some())
+    }
+}


### PR DESCRIPTION
### TL;DR

Added repositories for tracking land positions, PnL processing, and event logs to support user portfolio tracking.

### What changed?

- Added new repository modules:
  - `land_position.rs`: Manages land ownership positions with methods for creating, retrieving, and updating position data
  - `pnl_processor_state.rs`: Tracks the state of the PnL processor to resume processing from the last point
  - `position_event_log.rs`: Records events related to positions for audit and history tracking

- Enhanced existing repositories:
  - Added `get_events_after` method to `event.rs` to retrieve events after a specific timestamp
  - Added `get_by_location` methods to both `land.rs` and `land_stake.rs` to retrieve the latest land and stake data for a specific location
  - Added `serde_json` as a workspace dependency

### How to test?

- Create a new land position and verify it can be retrieved by owner and location
- Test the event retrieval by fetching events after a specific timestamp
- Test position event logging by creating log entries and retrieving them
- Verify PnL processor state can be updated and retrieved correctly

### Why make this change?

These repositories provide the data access layer needed for tracking user positions, calculating profit and loss, and maintaining an audit trail of position-related events. This infrastructure will support portfolio tracking features, allowing users to see their land ownership history, stake activity, and investment performance over time.