### PR TITLE
fix: Fixed lagging events

### DIFF
--- a/crates/chaindata/service/src/lib.rs
+++ b/crates/chaindata/service/src/lib.rs
@@ -11,7 +11,7 @@ use tasks::{
     event_listener::EventListenerTask, land_historical_listener::LandHistoricalListenerTask,
     model_listener::ModelListenerTask, Task, TaskWrapper,
 };
-use tokio::sync::broadcast;
+use tokio::sync::mpsc;
 use torii_ingester::{ToriiClient, ToriiConfiguration};
 
 /// `ChainDataService` is a service that handles the importation and syncing of new events and data
@@ -50,7 +50,7 @@ impl ChainDataService {
         let land_historical_repository = Arc::new(LandHistoricalRepository::new(database.clone()));
 
         // Create a broadcast channel for event communication
-        let (event_sender, event_receiver) = broadcast::channel(1000);
+        let (event_sender, event_receiver) = mpsc::channel(10);
 
         Ok(Arc::new(Self {
             event_listener_task: EventListenerTask::new(


### PR DESCRIPTION
Converted the broadcast channel to a back-pressure enabled mpsc queue.

That means that when catching up with old events, the fetching will not continue until
the land historical task has processed all the new events, ensureing that all events
gets processed.

Note that this might not always be the good solution, it's just that in that case,
it makes sense and is easy to manage, especially due to the fact that on crash, it
will just skip some events (the size of the mpsc queue), and then resume as if nothing
has happenned.

Long term solution would be to store some processing state into the database, where the
tasks pull at their own rate, but we need something that works today :)