### PR TITLE
fix nuke time

### DIFF
--- a/client/src/lib/components/+game-map/three/utils/nuke-time-manager.svelte.ts
+++ b/client/src/lib/components/+game-map/three/utils/nuke-time-manager.svelte.ts
@@ -24,7 +24,7 @@ interface CachedNukeTime {
   timeInSeconds: number;
   lastCalculated: number;
   elapsedTimes?: any[];
-  minElapsedTime?: number;
+  maxElapsedTime?: number;
 }
 
 export class NukeTimeManager {
@@ -102,9 +102,9 @@ export class NukeTimeManager {
           const elapsedTimes =
             await landWithActions.getElapsedTimeSinceLastClaimForNeighbors();
 
-          // Calculate min elapsed time
-          const minElapsedTime = elapsedTimes?.length
-            ? Math.min(...elapsedTimes.map((neighbor) => Number(neighbor[1])))
+          // Calculate max elapsed time (oldest claim - the bottleneck)
+          const maxElapsedTime = elapsedTimes?.length
+            ? Math.max(...elapsedTimes.map((neighbor) => Number(neighbor[1])))
             : undefined;
 
           // Get neighbor count
@@ -115,7 +115,7 @@ export class NukeTimeManager {
           const timeInSeconds = estimateNukeTimeSync(
             landWithActions,
             neighborCount,
-            minElapsedTime,
+            maxElapsedTime,
           );
 
           // Update cache
@@ -123,7 +123,7 @@ export class NukeTimeManager {
             timeInSeconds,
             lastCalculated: Date.now(),
             elapsedTimes,
-            minElapsedTime,
+            maxElapsedTime,
           });
 
           // Force reactivity update
@@ -198,11 +198,11 @@ export class NukeTimeManager {
 
           if (neighborCount > 0) {
             // If we have cached elapsed times, use them
-            if (cachedResult?.minElapsedTime !== undefined) {
+            if (cachedResult?.maxElapsedTime !== undefined) {
               const timeInSeconds = estimateNukeTimeSync(
                 landWithActions,
                 neighborCount,
-                cachedResult.minElapsedTime,
+                cachedResult.maxElapsedTime,
               );
               const { text, shieldType } = this.formatNukeTime(timeInSeconds);
               dataMap.set(locationKey, {

--- a/client/src/lib/utils/taxes.ts
+++ b/client/src/lib/utils/taxes.ts
@@ -151,8 +151,8 @@ export const estimateNukeTime = async (
     return remainingSeconds;
   }
 
-  // Find the minimum elapsed time (most recent claim)
-  const minElapsedTime = Math.min(
+  // Find the maximum elapsed time (oldest claim) - this is the bottleneck
+  const maxElapsedTime = Math.max(
     ...elapsedTimesOfNeighbors.map((neighbor) => Number(neighbor[1])),
   );
 
@@ -162,7 +162,7 @@ export const estimateNukeTime = async (
 
   // Use the smaller of: neighbor's elapsed time OR land age
   // (Can't owe taxes from before you owned the land)
-  const relevantElapsedTime = Math.min(minElapsedTime, landAge);
+  const relevantElapsedTime = Math.min(maxElapsedTime, landAge);
 
   return Math.max(0, Math.floor(remainingSeconds - relevantElapsedTime));
 };


### PR DESCRIPTION
### TL;DR

Fixed nuke time calculation to use the oldest neighbor claim instead of the newest.

### What changed?

- Changed the nuke time calculation logic to use the maximum elapsed time (oldest claim) instead of the minimum elapsed time (newest claim)
- Renamed variables from `minElapsedTime` to `maxElapsedTime` to better reflect their purpose
- Updated comments to clarify that the oldest claim represents the bottleneck in the nuke time calculation

### How to test?

1. View a land tile with multiple neighbors
2. Check that the nuke time displayed correctly reflects the time based on the oldest neighboring claim
3. Verify that lands with neighbors who claimed a long time ago show shorter nuke times than those with recently claimed neighbors

### Why make this change?

The previous implementation incorrectly used the most recent neighbor claim to calculate nuke times, which resulted in inaccurate estimates. The correct approach is to use the oldest neighbor claim as the bottleneck, since that's what determines when a land can be nuked. This change ensures players receive accurate information about when their land becomes vulnerable to nuking.