### PR TITLE
Add advisor warnings to buy-sell form

### DIFF
--- a/client/src/lib/components/+game-ui/widgets/land-info/tabs/buy-tab.svelte
+++ b/client/src/lib/components/+game-ui/widgets/land-info/tabs/buy-tab.svelte
@@ -557,36 +557,6 @@
         <p class="text-red-500 text-sm mt-1">{balanceError}</p>
       {/if}
 
-      <Card class="bg-red-600/50 ponzi-bg bg-blend-overlay m-0 mt-4">
-        <div class="flex justify-stretch">
-          <img
-            src="/ui/icons/Icon_ShieldRed.png"
-            alt="Shield Red Icon"
-            class="w-8 h-8 mr-2"
-          />
-
-          <span class="text-lg">
-            You land will never pay for itself, as you pay more in taxes than
-            you earn back !
-          </span>
-        </div>
-      </Card>
-
-      <Card class="bg-orange-300/50 ponzi-bg bg-blend-overlay m-0 mt-4">
-        <div class="flex justify-stretch">
-          <img
-            src="/ui/icons/Icon_ShieldOrange.png"
-            alt="Shield Orange Icon"
-            class="w-8 h-8 mr-2"
-          />
-
-          <span class="text-lg">
-            If someone buys your land immediately, you will loose 0.26$ ! You
-            might want to increase the sell price to avoid this.
-          </span>
-        </div>
-      </Card>
-
       {#if loading}
         <Button class="mt-3 w-full" disabled>
           buying <ThreeDots />

--- a/client/src/lib/components/+game-ui/widgets/land-info/tax-impact/tax-impact.svelte
+++ b/client/src/lib/components/+game-ui/widgets/land-info/tax-impact/tax-impact.svelte
@@ -493,12 +493,12 @@
         if (profitPercent <= -20) {
           warnings.push({
             type: 'strong',
-            message: `If your land is bought by another player, you will get ${netSellerProceedsInSelectedToken?.toString() || '0'} ${selectedToken?.symbol}, which is ${actualSellBenefit.rawValue().abs().toString()} ${baseToken?.symbol} less than what you will be spending to buy the land.`,
+            message: `If your land is bought by another player, you will get ${netSellerProceedsInSelectedToken?.toString() || '0'} ${selectedToken?.symbol}, which is ${actualSellBenefit.rawValue().abs().decimalPlaces(2).toString()} ${baseToken?.symbol} less than what you will be spending to buy the land.`,
           });
         } else if (profitPercent <= -10) {
           warnings.push({
             type: 'weak',
-            message: `If your land is bought by another player, you will get ${netSellerProceedsInSelectedToken?.toString() || '0'} ${selectedToken?.symbol}, which is ${actualSellBenefit.rawValue().abs().toString()} ${baseToken?.symbol} less than what you will be spending to buy the land.`,
+            message: `If your land is bought by another player, you will get ${netSellerProceedsInSelectedToken?.toString() || '0'} ${selectedToken?.symbol}, which is ${actualSellBenefit.rawValue().abs().decimalPlaces(2).toString()} ${baseToken?.symbol} less than what you will be spending to buy the land.`,
           });
         }
       }
@@ -533,30 +533,6 @@
     >
       ⚠️ Cannot convert token prices - calculations may be inaccurate
     </div>
-  {/if}
-
-  <!-- Advisor Warnings -->
-  {#if advisorWarnings.length > 0}
-    {#each advisorWarnings as warning}
-      <Card
-        class="bg-ponzi bg-blend-overlay m-0 mt-4 p-3"
-        class:bg-red-600/50={warning.type === 'strong'}
-        class:bg-orange-300/50={warning.type === 'weak'}
-      >
-        <div class="flex justify-stretch items-start">
-          <img
-            src="/ui/icons/Icon_Shield{warning.type === 'strong'
-              ? 'Red'
-              : 'Orange'}.png"
-            alt="Shield {warning.type === 'strong' ? 'Red' : 'Orange'} Icon"
-            class="w-8 h-8 mr-2 flex-shrink-0"
-          />
-          <span class="text-lg leading-tight">
-            {warning.message}
-          </span>
-        </div>
-      </Card>
-    {/each}
   {/if}
 
   <!-- Horizontal Slider Above -->
@@ -640,4 +616,28 @@
       {/if}
     </ScrollArea>
   </div>
+
+  <!-- Advisor Warnings -->
+  {#if advisorWarnings.length > 0}
+    {#each advisorWarnings as warning}
+      <Card
+        class="ponzi-bg bg-blend-overlay m-0 mt-4 p-3 {warning.type === 'strong'
+          ? 'bg-red-600/50'
+          : 'bg-orange-300/50'}"
+      >
+        <div class="flex justify-stretch items-start">
+          <img
+            src="/ui/icons/Icon_Shield{warning.type === 'strong'
+              ? 'Red'
+              : 'Orange'}.png"
+            alt="Shield {warning.type === 'strong' ? 'Red' : 'Orange'} Icon"
+            class="w-8 h-8 mr-2 flex-shrink-0"
+          />
+          <span class="text-lg leading-tight">
+            {warning.message}
+          </span>
+        </div>
+      </Card>
+    {/each}
+  {/if}
 </div>


### PR DESCRIPTION
Add an advisor feature that displays contextual warnings to users when buying land:

- Weak warning when payback time exceeds nuke time by >10%
- Weak/strong warning when sell profit is negative (-10% to -20% weak, >-20% strong)
- Weak warning when taxes exceed yield from neighbors

The warnings use Card components with red/orange backgrounds and shield icons to alert users of potential issues with their land purchase decisions.