### PR TITLE
"Total Staked" feature in the wallet widget.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,3 +177,95 @@ Use centralized date utilities from `$lib/utils/date` for consistent date format
 
 ## Dev Tips and Gotchas
 - When you add a nix file, add it to the git before trying to run a command. Otherwise you might get a file not found error.
+
+## Communication Style
+
+- Never use phrases like "Perfect!", "Here is the implementation", "Great!", or similar filler language
+- Be direct and concise in responses
+- Focus on the work, not on narrating it
+
+## Git Workflow
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:**
+
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation only
+- `style`: Formatting, no code change
+- `refactor`: Code change that neither fixes a bug nor adds a feature
+- `test`: Adding or updating tests
+- `chore`: Maintenance tasks
+
+**Rules:**
+
+- First line must be clear and descriptive (max 72 characters)
+- Use imperative mood ("add feature" not "added feature")
+- No period at the end of the subject line
+
+**Examples:**
+
+```
+feat: add challenge expiration timer
+fix: prevent duplicate factory closures
+refactor(wallet): simplify balance calculation
+```
+
+### Graphite Workflow
+
+1. **Track branches**: After creating a branch, run:
+
+   ```bash
+   gt track
+   ```
+
+2. **Submit for review**: When task is complete (after all checks pass):
+   ```bash
+   gt submit
+   ```
+
+## Pre-Submit Checklist
+
+Before marking a task as done, run these commands and fix any issues:
+
+```bash
+# 1. Format code
+bun prettier --write .
+
+# 2. Lint and fix
+bun lint
+
+# 3. Type check
+bun check
+```
+
+Fix all errors before submitting. Do not submit code with formatting, linting, or type errors.
+
+## Vibe Kanban Integration
+
+Tasks are tracked through Vibe Kanban. The branch naming convention follows the pattern:
+
+```
+<initials>/<ticket-number>-<short-description>
+```
+
+Example: `vk/2844-create-agent-md`
+
+When working on a task:
+
+1. Ensure you're on the correct branch for the ticket
+2. Track the branch with `gt track`
+3. Make commits following conventional commits
+4. Run all checks before completing
+5. Submit with `gt submit` when done

--- a/client/src/lib/components/+game-ui/widgets/command-center/game-statistics/portfolio-summary.svelte
+++ b/client/src/lib/components/+game-ui/widgets/command-center/game-statistics/portfolio-summary.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import type { LandWithActions } from '$lib/api/land';
+  import { walletStore } from '$lib/stores/wallet.svelte';
+  import { settingsStore } from '$lib/stores/settings.store.svelte';
+  import { displayCurrency } from '$lib/utils/currency';
+  import data from '$profileData';
+
+  interface Props {
+    lands: LandWithActions[];
+  }
+
+  let { lands }: Props = $props();
+
+  let baseToken = $derived.by(() => {
+    const selectedAddress = settingsStore.selectedBaseTokenAddress;
+    const targetAddress = selectedAddress || data.mainCurrencyAddress;
+    return data.availableTokens.find(
+      (token) => token.address === targetAddress,
+    );
+  });
+
+  let portfolioStats = $derived.by(() => {
+    if (!baseToken || !lands.length)
+      return { totalStakedUsd: 0, totalSellValueUsd: 0 };
+
+    let totalStakedUsd = 0;
+    let totalSellValueUsd = 0;
+
+    for (const land of lands) {
+      const token = land.token;
+      if (!token) continue;
+
+      // Stake
+      if (land.stakeAmount) {
+        const stakedUsd = walletStore.convertTokenAmount(
+          land.stakeAmount,
+          token,
+          baseToken,
+        );
+        if (stakedUsd) totalStakedUsd += Number(stakedUsd.rawValue());
+      }
+      // Sell value
+      if (land.sellPrice) {
+        const sellUsd = walletStore.convertTokenAmount(
+          land.sellPrice,
+          token,
+          baseToken,
+        );
+        if (sellUsd) totalSellValueUsd += Number(sellUsd.rawValue());
+      }
+    }
+
+    return { totalStakedUsd, totalSellValueUsd };
+  });
+</script>
+
+<div class="flex flex-col gap-3">
+  <div class="text-sm font-semibold opacity-70 flex items-center gap-2">
+    <img src="/ui/icons/IconTiny_Stats.png" alt="Stats" class="h-4 w-4" />
+    Portfolio Value
+  </div>
+
+  {#if lands.length === 0}
+    <div class="text-center text-sm opacity-50">No lands owned</div>
+  {:else}
+    <div class="bg-black/20 rounded-lg p-3">
+      <div class="grid grid-cols-2 gap-4">
+        <div class="text-center">
+          <div class="text-xs opacity-50">Total Staked</div>
+          <div class="font-ponzi-number text-lg">
+            {displayCurrency(portfolioStats.totalStakedUsd)} $
+          </div>
+        </div>
+        <div class="text-center">
+          <div class="text-xs opacity-50">Total Sell Value</div>
+          <div class="font-ponzi-number text-lg">
+            {displayCurrency(portfolioStats.totalSellValueUsd)} $
+          </div>
+        </div>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/client/src/lib/components/+game-ui/widgets/command-center/game-statistics/widget-game-statistics.svelte
+++ b/client/src/lib/components/+game-ui/widgets/command-center/game-statistics/widget-game-statistics.svelte
@@ -11,6 +11,7 @@
   import account from '$lib/account.svelte';
   import type { Snippet } from 'svelte';
   import DailySummary from './daily-summary.svelte';
+  import PortfolioSummary from './portfolio-summary.svelte';
   import BuildingHighlights from './building-highlights.svelte';
   import GameStats from './game-stats.svelte';
 
@@ -97,6 +98,10 @@
   <ScrollArea type="scroll" class="h-full">
     <div class="flex flex-col gap-4 p-2">
       <DailySummary {lands} />
+
+      <Separator class="opacity-30" />
+
+      <PortfolioSummary {lands} />
 
       <Separator class="opacity-30" />
 

--- a/client/src/lib/components/+game-ui/widgets/wallet/wallet-balance.svelte
+++ b/client/src/lib/components/+game-ui/widgets/wallet/wallet-balance.svelte
@@ -277,52 +277,14 @@
   {/if}
 </div>
 
-<!-- Staked in Lands section -->
-<div class="flex items-center border-t border-gray-700 mt-2 gap-2 p-2">
-  <span class="font-ponzi-number">
-    Staked
-    <InfoTooltip text="Total tokens locked as stakes across your lands" />
-  </span>
-
-  <div class="flex flex-1 items-center gap-2 justify-end select-text"></div>
-  {#if totalStakedUsd && baseToken}
-    <div
-      class="font-ponzi-number px-1 rounded flex items-center gap-1"
-      title="Total staked value in USDC"
-    >
-      <div class="font-ponzi-number">
-        {totalStakedUsd.toString()}
-      </div>
-      <TokenAvatar token={baseToken} class="h-6 w-6" />
-    </div>
-  {:else}
-    <div class="font-ponzi-number text-gray-500">$0</div>
-  {/if}
-</div>
-
-<!-- Staked tokens breakdown -->
-{#if stakedByToken.size > 0}
-  <div class="flex flex-col gap-1 px-2 py-1 border-t border-gray-700/50">
-    {#each [...stakedByToken.entries()] as [tokenAddress, { token, amount }]}
-      {@const convertedAmount = walletStore.convertTokenAmount(
-        amount,
-        token,
-        baseToken!,
-      )}
-      <div class="flex items-center gap-2 text-sm">
-        <TokenAvatar {token} class="h-5 w-5" />
-        <span class="font-ponzi-number">{amount.toString()}</span>
-        {#if convertedAmount && baseToken}
-          <span class="text-gray-400 text-xs ml-auto">
-            ≈ {convertedAmount.toString()}
-            <TokenAvatar
-              token={baseToken}
-              class="h-4 w-4 inline-block ml-0.5"
-            />
-          </span>
-        {/if}
-      </div>
-    {/each}
+<!-- Staked amount (smaller, below balance) -->
+{#if totalStakedUsd && baseToken}
+  <div class="flex items-center justify-end gap-1 px-2 -mt-1 mb-1">
+    <span class="text-xs text-gray-400">Staked:</span>
+    <span class="text-xs font-ponzi-number text-gray-400">
+      {totalStakedUsd.toString()}
+    </span>
+    <TokenAvatar token={baseToken} class="h-4 w-4 opacity-50" />
   </div>
 {/if}
 

--- a/client/src/lib/components/+game-ui/widgets/wallet/wallet-balance.svelte
+++ b/client/src/lib/components/+game-ui/widgets/wallet/wallet-balance.svelte
@@ -17,6 +17,7 @@
   import { BuildingLand } from '$lib/api/land/building_land';
   import type { Token } from '$lib/interfaces';
   import { CurrencyAmount } from '$lib/utils/CurrencyAmount';
+  import { get } from 'svelte/store';
 
   let {
     setCustomControls,
@@ -144,12 +145,15 @@
 
   // Calculate staked amounts from owned lands
   const stakedByToken = $derived.by(() => {
-    const stakeMap = new Map<string, { token: Token; amount: CurrencyAmount }>();
+    const stakeMap = new Map<
+      string,
+      { token: Token; amount: CurrencyAmount }
+    >();
 
     if (!address) return stakeMap;
 
     const normalizedAddress = padAddress(address);
-    const allLands = landStore.getAllLands();
+    const allLands = get(landStore.getAllLands());
 
     for (const land of allLands) {
       if (!BuildingLand.is(land)) continue;
@@ -181,7 +185,11 @@
     let total = CurrencyAmount.fromScaled(0, baseToken);
 
     for (const [, { token, amount }] of stakedByToken) {
-      const converted = walletStore.convertTokenAmount(amount, token, baseToken);
+      const converted = walletStore.convertTokenAmount(
+        amount,
+        token,
+        baseToken,
+      );
       if (converted) {
         total = total.add(converted);
       }
@@ -307,7 +315,10 @@
         {#if convertedAmount && baseToken}
           <span class="text-gray-400 text-xs ml-auto">
             ≈ {convertedAmount.toString()}
-            <TokenAvatar token={baseToken} class="h-4 w-4 inline-block ml-0.5" />
+            <TokenAvatar
+              token={baseToken}
+              class="h-4 w-4 inline-block ml-0.5"
+            />
           </span>
         {/if}
       </div>

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -e
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+# Check if a port is in use
+is_port_in_use() {
+    local port=$1
+    if lsof -i ":$port" &>/dev/null; then
+        return 0  # Port is in use
+    else
+        return 1  # Port is free
+    fi
+}
+
+# Find the next available port starting from a given port
+find_available_port() {
+    local port=$1
+    local max_attempts=100
+    local attempts=0
+
+    while is_port_in_use "$port"; do
+        ((attempts++))
+        if [ "$attempts" -ge "$max_attempts" ]; then
+            echo "Error: Could not find an available port after $max_attempts attempts starting from $1" >&2
+            exit 1
+        fi
+        ((port++))
+    done
+
+    echo "$port"
+}
+
+echo -e "${BLUE}Starting PonziLand Development Environment${NC}"
+echo ""
+
+if ! command -v nix &> /dev/null; then
+    echo "Error: Nix is not installed. Please install Nix first."
+    echo "Visit: https://nixos.org/download.html"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if [ ! -f "flake.nix" ]; then
+    echo "Error: flake.nix not found in $SCRIPT_DIR"
+    echo "This script must be run from the PonziLand project root."
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Nix found${NC}"
+echo -e "${GREEN}✓ In correct directory: $SCRIPT_DIR${NC}"
+echo ""
+
+echo -e "${BLUE}Installing client dependencies...${NC}"
+cd "$SCRIPT_DIR/client"
+bun install
+cd "$SCRIPT_DIR"
+echo -e "${GREEN}✓ Dependencies installed${NC}"
+echo ""
+
+# Default ports
+DEFAULT_PG_PORT=5432
+DEFAULT_PGADMIN_PORT=5050
+DEFAULT_VITE_PORT=5173
+
+echo -e "${BLUE}Checking port availability...${NC}"
+
+PG_PORT=$(find_available_port $DEFAULT_PG_PORT)
+if [ "$PG_PORT" -ne "$DEFAULT_PG_PORT" ]; then
+    echo -e "${YELLOW}⚠ Port $DEFAULT_PG_PORT in use, using port $PG_PORT for PostgreSQL${NC}"
+else
+    echo -e "${GREEN}✓ PostgreSQL port $PG_PORT available${NC}"
+fi
+
+PGADMIN_PORT=$(find_available_port $DEFAULT_PGADMIN_PORT)
+if [ "$PGADMIN_PORT" -ne "$DEFAULT_PGADMIN_PORT" ]; then
+    echo -e "${YELLOW}⚠ Port $DEFAULT_PGADMIN_PORT in use, using port $PGADMIN_PORT for PGAdmin${NC}"
+else
+    echo -e "${GREEN}✓ PGAdmin port $PGADMIN_PORT available${NC}"
+fi
+
+VITE_PORT=$(find_available_port $DEFAULT_VITE_PORT)
+if [ "$VITE_PORT" -ne "$DEFAULT_VITE_PORT" ]; then
+    echo -e "${YELLOW}⚠ Port $DEFAULT_VITE_PORT in use, using port $VITE_PORT for Frontend${NC}"
+else
+    echo -e "${GREEN}✓ Frontend port $VITE_PORT available${NC}"
+fi
+
+echo ""
+echo -e "${BLUE}Starting services:${NC}"
+echo -e "  PostgreSQL on port $PG_PORT"
+echo -e "  PGAdmin on port $PGADMIN_PORT"
+echo -e "  Frontend on port $VITE_PORT"
+echo ""
+
+# Export ports for nix to read (requires --impure flag)
+export PONZILAND_PG_PORT=$PG_PORT
+export PONZILAND_PGADMIN_PORT=$PGADMIN_PORT
+export PONZILAND_VITE_PORT=$VITE_PORT
+
+# Check if running in interactive terminal
+if [ -t 0 ] && [ -t 1 ]; then
+    # Interactive - use TUI
+    nix run --impure .#dev
+else
+    # Non-interactive - disable TUI
+    nix run --impure .#dev -- --tui=false
+fi

--- a/flake-modules/process-compose.nix
+++ b/flake-modules/process-compose.nix
@@ -1,4 +1,12 @@
-{inputs, ...}: {
+{inputs, ...}: let
+  # Read ports from environment variables (requires --impure flag)
+  pgPort = builtins.getEnv "PONZILAND_PG_PORT";
+  pgadminPort = builtins.getEnv "PONZILAND_PGADMIN_PORT";
+  vitePort = builtins.getEnv "PONZILAND_VITE_PORT";
+  pgPortNum = if pgPort == "" then 5432 else builtins.fromJSON pgPort;
+  pgadminPortNum = if pgadminPort == "" then 5050 else builtins.fromJSON pgadminPort;
+  vitePortNum = if vitePort == "" then 5173 else builtins.fromJSON vitePort;
+in {
   imports = [
     inputs.process-compose-flake.flakeModule
   ];
@@ -16,6 +24,7 @@
 
       services.postgres."pg1" = {
         enable = true;
+        port = pgPortNum;
         initialScript.before = ''
           CREATE USER chaindata WITH password 'chaindata';
         '';
@@ -38,6 +47,7 @@
 
       services.pgadmin."pgad1" = {
         enable = true;
+        port = pgadminPortNum;
         initialEmail = "test@runelabs.xyz";
         initialPassword = "password";
       };
@@ -47,7 +57,7 @@
         command = "${config.packages.migrate}/bin/migrate";
         depends_on."pg1".condition = "process_healthy";
         environment = {
-          DATABASE_URL = "postgres://chaindata:chaindata@127.0.0.1:5432/chaindata";
+          DATABASE_URL = "postgres://chaindata:chaindata@127.0.0.1:${toString pgPortNum}/chaindata";
         };
       };
 
@@ -57,13 +67,13 @@
         working_dir = "./crates/indexer";
         depends_on.migrate.condition = "process_completed_successfully";
         environment = {
-          DATABASE_URL = "postgres://chaindata:chaindata@127.0.0.1:5432/chaindata";
+          DATABASE_URL = "postgres://chaindata:chaindata@127.0.0.1:${toString pgPortNum}/chaindata";
         };
       };
 
-      # Run frontend in dev mode on Sepolia
+      # Run frontend in dev mode
       settings.processes.frontend-mainnet-local-api = {
-        command = "${pkgs.bun}/bin/bun dev:mainnet-local-api";
+        command = "${pkgs.bun}/bin/bun dev:mainnet-local-api --port ${toString vitePortNum}";
         working_dir = "./client";
       };
     };


### PR DESCRIPTION
I've implemented the "Total Staked" feature in the wallet widget. Here's a summary of the changes made to `wallet-balance.svelte`:

## Changes Made

### 1. Added imports (lines 15-19)
- `padAddress` from `$lib/utils` - for normalizing wallet addresses
- `landStore` from `$lib/stores/store.svelte` - for accessing land data
- `BuildingLand` from `$lib/api/land/building_land` - for type checking and accessing stake data
- `Token` type from `$lib/interfaces`
- `CurrencyAmount` from `$lib/utils/CurrencyAmount`

### 2. Added derived state for stakes (lines 145-191)
- **`stakedByToken`**: Iterates through all lands, filters to BuildingLand instances owned by the connected wallet, and groups stake amounts by token address
- **`totalStakedUsd`**: Converts all staked amounts to the base token (USDC) and sums them up

### 3. Added UI section (lines 272-316)
- **"Staked" header section**: Shows total staked value in USDC with an info tooltip explaining what it means
- **Token breakdown**: Lists each staked token with its amount and USD equivalent value (shown when user has stakes)

The display follows the existing styling patterns in the wallet widget with:
- Same font classes (`font-ponzi-number`)
- Same border styling (`border-t border-gray-700`)
- TokenAvatar components for token icons
- Fallback to "$0" when no stakes exist

All checks pass:
- **Type check**: `svelte-check found 0 errors and 0 warnings`
- **Prettier formatting**: Applied successfully

The fix was to import `get` from `svelte/store` and use `get(landStore.getAllLands())` instead of directly iterating over the store, since `getAllLands()` returns a `Readable<BaseLand[]>` (Svelte store) rather than a plain array.

All done. Here's a summary of the changes:

## Summary of Changes

### 1. Modified `building-highlights.svelte`
- Extended `TokenStats` interface to include `totalStaked`, `totalStakedUsd`, `totalSellValue`, `totalSellValueUsd`
- Added calculation logic inside the stats loop to sum up stake amounts and sell prices per token
- Added new UI row showing "Staked" and "Sell Value" for each token with USD equivalents

### 2. Created `portfolio-summary.svelte` (new file)
- New component that displays aggregated portfolio value
- Shows "Total Staked" and "Total Sell Value" in USDC
- Follows existing UI patterns (bg-black/20 card, font-ponzi-number, etc.)

### 3. Updated `widget-game-statistics.svelte`
- Added import for `PortfolioSummary`
- Inserted `<PortfolioSummary {lands} />` between DailySummary and BuildingHighlights

### Final Layout
```
widget-game-statistics.svelte
├─ DailySummary (daily earnings/costs)
├─ Separator
├─ PortfolioSummary (NEW - total staked + sell value in USDC)
├─ Separator
├─ BuildingHighlights (token breakdown - NOW with staked/sell per token)
├─ Separator
└─ GameStats (historical stats)
```

All checks pass:
- **Type check**: `svelte-check found 0 errors and 0 warnings`
- **Prettier**: All files formatted correctly

Done. The wallet widget now shows the staked amount in a smaller, simpler format right below the balance:

**Before:**
- Separate "Staked" section with border and InfoTooltip
- Full token breakdown list showing each token's stake amount

**After:**
- Small inline text "Staked: {amount}" right below the balance line
- Muted gray color (`text-gray-400`) and smaller size (`text-xs`)
- No token breakdown details

All checks pass:
- `svelte-check found 0 errors and 0 warnings`
- Prettier formatting: unchanged (already formatted)